### PR TITLE
Update README.md to make example working

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ To import the library, add the following line to your file:
 
 ```csharp
 using Microsoft.Research.Zen;
+using static Microsoft.Research.Zen.Language;
 ```
 
 The main abstraction Zen provides is through the type `Zen<T>` which represents a value of type `T` that can be either concrete or symbolic. As a simple example, consider the following code:


### PR DESCRIPTION
The README is missing `using static Microsoft.Research.Zen.Language;`, this means that `Function`, `And` and other functions won't be found.