### PR TITLE
String support for Zen

### DIFF
--- a/ZenLib/CommonUtilities.cs
+++ b/ZenLib/CommonUtilities.cs
@@ -123,17 +123,5 @@ namespace ZenLib
                 throw new ArgumentException($"Invalid non-integer type {type} used as integer.");
             }
         }
-
-        /// <summary>
-        /// Validate that a type is string.
-        /// </summary>
-        /// <param name="type"></param>
-        public static void ValidateIsStringType(Type type)
-        {
-            if (type != ReflectionUtilities.StringType)
-            {
-                throw new ArgumentException($"Invalid non-string type {type} used as string.");
-            }
-        }
     }
 }

--- a/ZenLib/CommonUtilities.cs
+++ b/ZenLib/CommonUtilities.cs
@@ -123,5 +123,17 @@ namespace ZenLib
                 throw new ArgumentException($"Invalid non-integer type {type} used as integer.");
             }
         }
+
+        /// <summary>
+        /// Validate that a type is string.
+        /// </summary>
+        /// <param name="type"></param>
+        public static void ValidateIsStringType(Type type)
+        {
+            if (type != ReflectionUtilities.StringType)
+            {
+                throw new ArgumentException($"Invalid non-string type {type} used as string.");
+            }
+        }
     }
 }

--- a/ZenLib/Compilation/ExpressionConverter.cs
+++ b/ZenLib/Compilation/ExpressionConverter.cs
@@ -335,6 +335,17 @@ namespace ZenLib.Compilation
         }
 
         /// <summary>
+        /// Convert a constant string expression.
+        /// </summary>
+        /// <param name="expression">The expression.</param>
+        /// <param name="parameter">The parameter.</param>
+        /// <returns>The compilable expression.</returns>
+        public Expression VisitZenConstantStringExpr(ZenConstantStringExpr expression, ExpressionConverterEnvironment parameter)
+        {
+            return Expression.Constant(expression.Value);
+        }
+
+        /// <summary>
         /// Create an object given the fields.
         /// </summary>
         /// <typeparam name="TObject">The object type.</typeparam>
@@ -708,6 +719,22 @@ namespace ZenLib.Compilation
                 return Add<T>(
                     expression.Expr1.Accept(this, parameter),
                     expression.Expr2.Accept(this, parameter));
+            });
+        }
+
+        /// <summary>
+        /// Convert a 'Concat' expression.
+        /// </summary>
+        /// <param name="expression">The expression.</param>
+        /// <param name="parameter">The parameter.</param>
+        /// <returns>The compilable expression.</returns>
+        public Expression VisitZenConcatExpr<T>(ZenConcatExpr<T> expression, ExpressionConverterEnvironment parameter)
+        {
+            return LookupOrCompute(expression, () =>
+            {
+                var l = Expression.Convert(expression.Expr1.Accept(this, parameter), typeof(string));
+                var r = Expression.Convert(expression.Expr2.Accept(this, parameter), typeof(string));
+                return Expression.Add(l, r, typeof(string).GetMethod("Concat", new []{typeof(string), typeof(string)}));
             });
         }
 

--- a/ZenLib/Compilation/ExpressionConverter.cs
+++ b/ZenLib/Compilation/ExpressionConverter.cs
@@ -733,7 +733,7 @@ namespace ZenLib.Compilation
         /// <param name="expression">The expression.</param>
         /// <param name="parameter">The parameter.</param>
         /// <returns>The compilable expression.</returns>
-        public Expression VisitZenConcatExpr<T>(ZenConcatExpr<T> expression, ExpressionConverterEnvironment parameter)
+        public Expression VisitZenConcatExpr(ZenConcatExpr expression, ExpressionConverterEnvironment parameter)
         {
             return LookupOrCompute(expression, () =>
             {

--- a/ZenLib/Compilation/ExpressionConverter.cs
+++ b/ZenLib/Compilation/ExpressionConverter.cs
@@ -84,6 +84,11 @@ namespace ZenLib.Compilation
         private int maxMatchUnrollingDepth;
 
         /// <summary>
+        /// String concatenation method.
+        /// </summary>
+        private static MethodInfo concatMethod = typeof(string).GetMethod("Concat", new[] { typeof(string), typeof(string) });
+
+        /// <summary>
         /// Lookup an existing variable for the expression if defined.
         /// Otherwise, compile the expression, assign it a variable, and
         /// return this variable. Add the assignment to the blockExpressions.
@@ -734,7 +739,7 @@ namespace ZenLib.Compilation
             {
                 var l = Expression.Convert(expression.Expr1.Accept(this, parameter), typeof(string));
                 var r = Expression.Convert(expression.Expr2.Accept(this, parameter), typeof(string));
-                return Expression.Add(l, r, typeof(string).GetMethod("Concat", new[] { typeof(string), typeof(string) }));
+                return Expression.Add(l, r, concatMethod);
             });
         }
 

--- a/ZenLib/Compilation/ExpressionConverter.cs
+++ b/ZenLib/Compilation/ExpressionConverter.cs
@@ -734,7 +734,7 @@ namespace ZenLib.Compilation
             {
                 var l = Expression.Convert(expression.Expr1.Accept(this, parameter), typeof(string));
                 var r = Expression.Convert(expression.Expr2.Accept(this, parameter), typeof(string));
-                return Expression.Add(l, r, typeof(string).GetMethod("Concat", new []{typeof(string), typeof(string)}));
+                return Expression.Add(l, r, typeof(string).GetMethod("Concat", new[] { typeof(string), typeof(string) }));
             });
         }
 

--- a/ZenLib/Generation/DefaultTypeGenerator.cs
+++ b/ZenLib/Generation/DefaultTypeGenerator.cs
@@ -100,5 +100,11 @@ namespace ZenLib.Generation
         {
             return ZenConstantUshortExpr.Create(0);
         }
+
+        // FIXME: default value for a c# string is null, not empty. How to represent null strings?
+        public object VisitString()
+        {
+            return ZenConstantStringExpr.Create("");
+        }
     }
 }

--- a/ZenLib/Generation/SymbolicInputGenerator.cs
+++ b/ZenLib/Generation/SymbolicInputGenerator.cs
@@ -150,6 +150,13 @@ namespace ZenLib.Generation
             return e;
         }
 
+        public object VisitString()
+        {
+            var e = new ZenArbitraryExpr<string>();
+            this.ArbitraryExpressions.Add(e);
+            return e;
+        }
+
         public object VisitOption(Func<Type, object> recurse, Type innerType)
         {
             var flag = recurse(ReflectionUtilities.BoolType);

--- a/ZenLib/ITypeVisitor.cs
+++ b/ZenLib/ITypeVisitor.cs
@@ -62,6 +62,12 @@ namespace ZenLib
         T VisitUlong();
 
         /// <summary>
+        /// Visit the string type.
+        /// </summary>
+        /// <returns>A value.</returns>
+        T VisitString();
+
+        /// <summary>
         /// Visit the option type.
         /// </summary>
         /// <returns>A value.</returns>

--- a/ZenLib/Interpretation/ExpressionEvaluator.cs
+++ b/ZenLib/Interpretation/ExpressionEvaluator.cs
@@ -564,6 +564,20 @@ namespace ZenLib.Interpretation
         }
 
         /// <summary>
+        /// Visit a ConcatExpr.
+        /// </summary>
+        /// <param name="expression">The expression.</param>
+        /// <param name="parameter">The parameter.</param>
+        /// <returns>The resulting C# value.</returns>
+        public object VisitZenConcatExpr<T>(ZenConcatExpr<T> expression, ExpressionEvaluatorEnvironment parameter)
+        {
+            return LookupOrCompute(expression, parameter, () =>
+            {
+                return (string)expression.Expr1.Accept(this, parameter) + (string)expression.Expr2.Accept(this, parameter);
+            });
+        }
+
+        /// <summary>
         /// Visit a IntConstantExpr.
         /// </summary>
         /// <param name="expression">The expression.</param>
@@ -625,6 +639,17 @@ namespace ZenLib.Interpretation
         /// <param name="parameter">The parameter.</param>
         /// <returns>The resulting C# value.</returns>
         public object VisitZenConstantUshortExpr(ZenConstantUshortExpr expression, ExpressionEvaluatorEnvironment parameter)
+        {
+            return expression.Value;
+        }
+
+        /// <summary>
+        /// Visit a ConstantStringExpr.
+        /// </summary>
+        /// <param name="expression">The expression.</param>
+        /// <param name="parameter">The parameter.</param>
+        /// <returns>The resulting C# value.</returns>
+        public object VisitZenConstantStringExpr(ZenConstantStringExpr expression, ExpressionEvaluatorEnvironment parameter)
         {
             return expression.Value;
         }

--- a/ZenLib/Interpretation/ExpressionEvaluator.cs
+++ b/ZenLib/Interpretation/ExpressionEvaluator.cs
@@ -569,7 +569,7 @@ namespace ZenLib.Interpretation
         /// <param name="expression">The expression.</param>
         /// <param name="parameter">The parameter.</param>
         /// <returns>The resulting C# value.</returns>
-        public object VisitZenConcatExpr<T>(ZenConcatExpr<T> expression, ExpressionEvaluatorEnvironment parameter)
+        public object VisitZenConcatExpr(ZenConcatExpr expression, ExpressionEvaluatorEnvironment parameter)
         {
             return LookupOrCompute(expression, parameter, () =>
             {

--- a/ZenLib/Language.cs
+++ b/ZenLib/Language.cs
@@ -606,6 +606,13 @@ namespace ZenLib
             CommonUtilities.Validate(expr1);
             CommonUtilities.Validate(expr2);
 
+            var type = typeof(T);
+
+            if (type == ReflectionUtilities.StringType)
+            {
+                return ZenConcatExpr<T>.Create(expr1, expr2);
+            }
+
             return ZenSumExpr<T>.Create(expr1, expr2);
         }
 

--- a/ZenLib/Language.cs
+++ b/ZenLib/Language.cs
@@ -606,14 +606,21 @@ namespace ZenLib
             CommonUtilities.Validate(expr1);
             CommonUtilities.Validate(expr2);
 
-            var type = typeof(T);
-
-            if (type == ReflectionUtilities.StringType)
-            {
-                return ZenConcatExpr<T>.Create(expr1, expr2);
-            }
-
             return ZenSumExpr<T>.Create(expr1, expr2);
+        }
+
+        /// <summary>
+        /// Compute the concatenation of two Zen strings.
+        /// </summary>
+        /// <param name="expr1">First Zen expressions.</param>
+        /// <param name="expr2">Second Zen expressions.</param>
+        /// <returns>Zen value.</returns>
+        public static Zen<string> Concat(Zen<string> expr1, Zen<string> expr2)
+        {
+            CommonUtilities.Validate(expr1);
+            CommonUtilities.Validate(expr2);
+
+            return ZenConcatExpr.Create(expr1, expr2);
         }
 
         /// <summary>

--- a/ZenLib/Language.cs
+++ b/ZenLib/Language.cs
@@ -139,6 +139,16 @@ namespace ZenLib
         }
 
         /// <summary>
+        /// The Zen value for a string.
+        /// </summary>
+        /// <param name="s">A string value.</param>
+        /// <returns>Zen value.</returns>
+        public static Zen<string> String(string s)
+        {
+            return ZenConstantStringExpr.Create(s);
+        }
+
+        /// <summary>
         /// A Zen object representing some arbitrary value.
         /// </summary>
         /// <param name="listSize">Depth bound on the size of the object.</param>

--- a/ZenLib/Language.cs
+++ b/ZenLib/Language.cs
@@ -458,7 +458,7 @@ namespace ZenLib
             {
                 var type = typeof(T);
 
-                if (type == ReflectionUtilities.BoolType || ReflectionUtilities.IsIntegerType(type))
+                if (type == ReflectionUtilities.BoolType || type == ReflectionUtilities.StringType || ReflectionUtilities.IsIntegerType(type))
                 {
                     return ZenEqExpr<T>.Create((dynamic)expr1, (dynamic)expr2);
                 }
@@ -610,7 +610,7 @@ namespace ZenLib
         }
 
         /// <summary>
-        /// Compute the sum of Zen values.
+        /// Compute the difference of Zen values.
         /// </summary>
         /// <param name="expr1">First Zen expressions.</param>
         /// <param name="expr2">Second Zen expressions.</param>

--- a/ZenLib/Language/IZenExprVisitor.cs
+++ b/ZenLib/Language/IZenExprVisitor.cs
@@ -145,7 +145,7 @@ namespace ZenLib
         /// <param name="expression">The expression.</param>
         /// <param name="parameter">The parameter.</param>
         /// <returns>A return value.</returns>
-        TReturn VisitZenConcatExpr<T>(ZenConcatExpr<T> expression, TParam parameter);
+        TReturn VisitZenConcatExpr(ZenConcatExpr expression, TParam parameter);
 
         /// <summary>
         /// Visit a MultiplyExpr.

--- a/ZenLib/Language/IZenExprVisitor.cs
+++ b/ZenLib/Language/IZenExprVisitor.cs
@@ -124,12 +124,28 @@ namespace ZenLib
         TReturn VisitZenConstantLongExpr(ZenConstantLongExpr expression, TParam parameter);
 
         /// <summary>
+        /// Visit a StringConstantExpr.
+        /// </summary>
+        /// <param name="expression">The expression.</param>
+        /// <param name="parameter">The parameter.</param>
+        /// <returns>A return value.</returns>
+        TReturn VisitZenConstantStringExpr(ZenConstantStringExpr expression, TParam parameter);
+
+        /// <summary>
         /// Visit a SumExpr.
         /// </summary>
         /// <param name="expression">The expression.</param>
         /// <param name="parameter">The parameter.</param>
         /// <returns>A return value.</returns>
         TReturn VisitZenSumExpr<T>(ZenSumExpr<T> expression, TParam parameter);
+
+        /// <summary>
+        /// Visit a ConcatExpr.
+        /// </summary>
+        /// <param name="expression">The expression.</param>
+        /// <param name="parameter">The parameter.</param>
+        /// <returns>A return value.</returns>
+        TReturn VisitZenConcatExpr<T>(ZenConcatExpr<T> expression, TParam parameter);
 
         /// <summary>
         /// Visit a MultiplyExpr.

--- a/ZenLib/Language/Zen.cs
+++ b/ZenLib/Language/Zen.cs
@@ -171,6 +171,13 @@ namespace ZenLib
         /// <returns>Zen expression.</returns>
         public static Zen<T> operator +(Zen<T> expr1, Zen<T> expr2)
         {
+            var type = typeof(T);
+
+            if (type == ReflectionUtilities.StringType)
+            {
+                return Language.Concat(expr1 as Zen<string>, expr2 as Zen<string>) as Zen<T>;
+            }
+
             return Language.Plus(expr1, expr2);
         }
 

--- a/ZenLib/Language/Zen.cs
+++ b/ZenLib/Language/Zen.cs
@@ -294,7 +294,7 @@ namespace ZenLib
         /// <summary>
         /// Convert an input to the Zen string type.
         /// </summary>
-        /// <param name="o">The object.</param>
+        /// <param name="s">The string.</param>
         /// <returns></returns>
         private static Zen<TZen> ConvertStringConstant<TZen>(string s)
         {

--- a/ZenLib/Language/Zen.cs
+++ b/ZenLib/Language/Zen.cs
@@ -89,6 +89,15 @@ namespace ZenLib
         }
 
         /// <summary>
+        /// Convert a string to the appropriate Zen type.
+        /// </summary>
+        /// <param name="x">The value.</param>
+        public static implicit operator Zen<T>(string x)
+        {
+            return ConvertStringConstant<T>((string)x);
+        }
+
+        /// <summary>
         /// Equality between two Zen objects.
         /// </summary>
         /// <param name="expr1">First Zen expression.</param>
@@ -280,6 +289,23 @@ namespace ZenLib
             }
 
             throw new ZenException($"Invalid implicit conversion from integer to type: {type}");
+        }
+
+        /// <summary>
+        /// Convert an input to the Zen string type.
+        /// </summary>
+        /// <param name="o">The object.</param>
+        /// <returns></returns>
+        private static Zen<TZen> ConvertStringConstant<TZen>(string s)
+        {
+            var type = typeof(TZen);
+
+            if (type == ReflectionUtilities.StringType)
+            {
+                return (Zen<TZen>)(object)Language.String(s);
+            }
+
+            throw new ZenException($"Invalid implicit conversion from string to type: {type}");
         }
 
         /// <summary>

--- a/ZenLib/Language/ZenConcatExpr.cs
+++ b/ZenLib/Language/ZenConcatExpr.cs
@@ -16,20 +16,20 @@ namespace ZenLib
 
         public static Zen<T> Simplify(Zen<T> e1, Zen<T> e2)
         {
-            var x = ReflectionUtilities.GetConstantString(e1);
-            var y = ReflectionUtilities.GetConstantString(e2);
+            string x = ReflectionUtilities.GetConstantString(e1);
+            string y = ReflectionUtilities.GetConstantString(e2);
 
-            if (x.HasValue && y.HasValue)
+            if (x != null && y != null)
             {
-                return ReflectionUtilities.CreateConstantString(x.Value + y.Value);
+                return ReflectionUtilities.CreateConstantString<T>(x + y);
             }
 
-            if (x.HasValue && x.Value.Equals(""))
+            if (x == "")
             {
                 return e2;
             }
 
-            if (y.HasValue && y.Value.Equals(""))
+            if (y == "")
             {
                 return e1;
             }

--- a/ZenLib/Language/ZenConcatExpr.cs
+++ b/ZenLib/Language/ZenConcatExpr.cs
@@ -1,0 +1,101 @@
+// <copyright file="ZenConcatExpr.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace ZenLib
+{
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+
+    /// <summary>
+    /// Class representing a Concat expression.
+    /// </summary>
+    internal sealed class ZenConcatExpr<T> : Zen<T>
+    {
+        private static Dictionary<(object, object), Zen<T>> hashConsTable = new Dictionary<(object, object), Zen<T>>();
+
+        public static Zen<T> Simplify(Zen<T> e1, Zen<T> e2)
+        {
+            var x = ReflectionUtilities.GetConstantString(e1);
+            var y = ReflectionUtilities.GetConstantString(e2);
+
+            if (x.HasValue && y.HasValue)
+            {
+                return ReflectionUtilities.CreateConstantString(x.Value + y.Value);
+            }
+
+            if (x.HasValue && x.Value.Equals(""))
+            {
+                return e2;
+            }
+
+            if (y.HasValue && y.Value.Equals(""))
+            {
+                return e1;
+            }
+
+            return new ZenConcatExpr<T>(e1, e2);
+        }
+
+        public static Zen<T> Create(Zen<T> expr1, Zen<T> expr2)
+        {
+            CommonUtilities.Validate(expr1);
+            CommonUtilities.Validate(expr2);
+            CommonUtilities.ValidateIsStringType(typeof(T));
+
+            var key = (expr1, expr2);
+            if (hashConsTable.TryGetValue(key, out var value))
+            {
+                return value;
+            }
+
+            var ret = Simplify(expr1, expr2);
+            hashConsTable[key] = ret;
+            return ret;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ZenConcatExpr{T}"/> class.
+        /// </summary>
+        /// <param name="expr1">The first expression.</param>
+        /// <param name="expr2">The second expression.</param>
+        private ZenConcatExpr(Zen<T> expr1, Zen<T> expr2)
+        {
+            this.Expr1 = expr1;
+            this.Expr2 = expr2;
+        }
+
+        /// <summary>
+        /// Gets the first expression.
+        /// </summary>
+        internal Zen<T> Expr1 { get; }
+
+        /// <summary>
+        /// Gets the second expression.
+        /// </summary>
+        internal Zen<T> Expr2 { get; }
+
+        /// <summary>
+        /// Convert the expression to a string.
+        /// </summary>
+        /// <returns>The string representation.</returns>
+        [ExcludeFromCodeCoverage]
+        public override string ToString()
+        {
+            return $"ZenConcatExpr({this.Expr1.ToString()}, {this.Expr2.ToString()})";
+        }
+
+        /// <summary>
+        /// Implementing the visitor interface.
+        /// </summary>
+        /// <param name="visitor">The visitor object.</param>
+        /// <param name="parameter">The visitor parameter.</param>
+        /// <typeparam name="TParam">The visitor parameter type.</typeparam>
+        /// <typeparam name="TReturn">The visitor return type.</typeparam>
+        /// <returns>A return value.</returns>
+        internal override TReturn Accept<TParam, TReturn>(IZenExprVisitor<TParam, TReturn> visitor, TParam parameter)
+        {
+            return visitor.VisitZenConcatExpr(this, parameter);
+        }
+    }
+}

--- a/ZenLib/Language/ZenConcatExpr.cs
+++ b/ZenLib/Language/ZenConcatExpr.cs
@@ -10,18 +10,18 @@ namespace ZenLib
     /// <summary>
     /// Class representing a Concat expression.
     /// </summary>
-    internal sealed class ZenConcatExpr<T> : Zen<T>
+    internal sealed class ZenConcatExpr : Zen<string>
     {
-        private static Dictionary<(object, object), Zen<T>> hashConsTable = new Dictionary<(object, object), Zen<T>>();
+        private static Dictionary<(object, object), Zen<string>> hashConsTable = new Dictionary<(object, object), Zen<string>>();
 
-        public static Zen<T> Simplify(Zen<T> e1, Zen<T> e2)
+        public static Zen<string> Simplify(Zen<string> e1, Zen<string> e2)
         {
             string x = ReflectionUtilities.GetConstantString(e1);
             string y = ReflectionUtilities.GetConstantString(e2);
 
             if (x != null && y != null)
             {
-                return ReflectionUtilities.CreateConstantString<T>(x + y);
+                return ReflectionUtilities.CreateConstantString(x + y);
             }
 
             if (x == "")
@@ -34,14 +34,13 @@ namespace ZenLib
                 return e1;
             }
 
-            return new ZenConcatExpr<T>(e1, e2);
+            return new ZenConcatExpr(e1, e2);
         }
 
-        public static Zen<T> Create(Zen<T> expr1, Zen<T> expr2)
+        public static Zen<string> Create(Zen<string> expr1, Zen<string> expr2)
         {
             CommonUtilities.Validate(expr1);
             CommonUtilities.Validate(expr2);
-            CommonUtilities.ValidateIsStringType(typeof(T));
 
             var key = (expr1, expr2);
             if (hashConsTable.TryGetValue(key, out var value))
@@ -55,11 +54,11 @@ namespace ZenLib
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ZenConcatExpr{T}"/> class.
+        /// Initializes a new instance of the <see cref="ZenConcatExpr"/> class.
         /// </summary>
         /// <param name="expr1">The first expression.</param>
         /// <param name="expr2">The second expression.</param>
-        private ZenConcatExpr(Zen<T> expr1, Zen<T> expr2)
+        private ZenConcatExpr(Zen<string> expr1, Zen<string> expr2)
         {
             this.Expr1 = expr1;
             this.Expr2 = expr2;
@@ -68,12 +67,12 @@ namespace ZenLib
         /// <summary>
         /// Gets the first expression.
         /// </summary>
-        internal Zen<T> Expr1 { get; }
+        internal Zen<string> Expr1 { get; }
 
         /// <summary>
         /// Gets the second expression.
         /// </summary>
-        internal Zen<T> Expr2 { get; }
+        internal Zen<string> Expr2 { get; }
 
         /// <summary>
         /// Convert the expression to a string.

--- a/ZenLib/Language/ZenConstantStringExpr.cs
+++ b/ZenLib/Language/ZenConstantStringExpr.cs
@@ -1,0 +1,66 @@
+// <copyright file="ZenConstantStringExpr.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace ZenLib
+{
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+
+    /// <summary>
+    /// Class representing a string constant expression.
+    /// </summary>
+    internal sealed class ZenConstantStringExpr : Zen<string>
+    {
+        private static Dictionary<string, Zen<string>> hashConsTable = new Dictionary<string, Zen<string>>();
+
+        public static Zen<string> Create(string value)
+        {
+            if (hashConsTable.TryGetValue(value, out var v))
+            {
+                return v;
+            }
+
+            var ret = new ZenConstantStringExpr(value);
+            hashConsTable[value] = ret;
+            return ret;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ZenConstantStringExpr"/> class.
+        /// </summary>
+        /// <param name="value">The value.</param>
+        private ZenConstantStringExpr(string value)
+        {
+            this.Value = value;
+        }
+
+        /// <summary>
+        /// Gets the value.
+        /// </summary>
+        internal string Value { get; }
+
+        /// <summary>
+        /// Convert the expression to a string.
+        /// </summary>
+        /// <returns>The string representation.</returns>
+        [ExcludeFromCodeCoverage]
+        public override string ToString()
+        {
+            return this.Value;
+        }
+
+        /// <summary>
+        /// Implementing the visitor interface.
+        /// </summary>
+        /// <param name="visitor">The visitor object.</param>
+        /// <param name="parameter">The visitor parameter.</param>
+        /// <typeparam name="TParam">The visitor parameter type.</typeparam>
+        /// <typeparam name="TReturn">The visitor return type.</typeparam>
+        /// <returns>A return value.</returns>
+        internal override TReturn Accept<TParam, TReturn>(IZenExprVisitor<TParam, TReturn> visitor, TParam parameter)
+        {
+            return visitor.VisitZenConstantStringExpr(this, parameter);
+        }
+    }
+}

--- a/ZenLib/ModelChecking/ISolver.cs
+++ b/ZenLib/ModelChecking/ISolver.cs
@@ -11,7 +11,8 @@ namespace ZenLib.ModelChecking
     /// <typeparam name="TVariable">The variable type.</typeparam>
     /// <typeparam name="TBool">The boolean expression type.</typeparam>
     /// <typeparam name="TInteger">The integer type.</typeparam>
-    public interface ISolver<TModel, TVariable, TBool, TInteger>
+    /// <typeparam name="TString">The string type.</typeparam>
+    public interface ISolver<TModel, TVariable, TBool, TInteger, TString>
     {
         /// <summary>
         /// The false expression.
@@ -83,6 +84,19 @@ namespace ZenLib.ModelChecking
         /// </summary>
         /// <returns></returns>
         TInteger CreateLongConst(long l);
+
+        /// <summary>
+        /// Create a new string expression.
+        /// </summary>
+        /// <param name="e">Zen arbitrary expr.</param>
+        /// <returns>The expression</returns>
+        (TVariable, TString) CreateStringVar(object e);
+
+        /// <summary>
+        /// Create a string constant.
+        /// </summary>
+        /// <returns></returns>
+        TString CreateStringConst(string s);
 
         /// <summary>
         /// The 'And' of two expressions.
@@ -171,12 +185,28 @@ namespace ZenLib.ModelChecking
         TInteger Multiply(TInteger x, TInteger y);
 
         /// <summary>
-        /// The 'Equal' of two expressions.
+        /// The 'Concat' of two expressions.
+        /// </summary>
+        /// <param name="x">The first expression.</param>
+        /// <param name="y">The second expression.</param>
+        /// <returns></returns>
+        TString Concat(TString x, TString y);
+
+        /// <summary>
+        /// The 'Equal' of two integers.
         /// </summary>
         /// <param name="x">The first expression.</param>
         /// <param name="y">The second expression.</param>
         /// <returns></returns>
         TBool Eq(TInteger x, TInteger y);
+
+        /// <summary>
+        /// The 'Equal' of two strings.
+        /// </summary>
+        /// <param name="x">The first expression.</param>
+        /// <param name="y">The second expression.</param>
+        /// <returns></returns>
+        TBool Eq(TString x, TString y);
 
         /// <summary>
         /// The 'LessThanOrEqual' of two expressions.
@@ -220,13 +250,22 @@ namespace ZenLib.ModelChecking
         TBool Ite(TBool g, TBool t, TBool f);
 
         /// <summary>
-        /// The 'Ite' of a guard and two expressions.
+        /// The 'Ite' of a guard and two integers.
         /// </summary>
         /// <param name="g">The guard expression.</param>
         /// <param name="t">The true expression.</param>
         /// <param name="f">The false expression.</param>
         /// <returns></returns>
         TInteger Ite(TBool g, TInteger t, TInteger f);
+
+        /// <summary>
+        /// The 'Ite' of a guard and two integers.
+        /// </summary>
+        /// <param name="g">The guard expression.</param>
+        /// <param name="t">The true expression.</param>
+        /// <param name="f">The false expression.</param>
+        /// <returns></returns>
+        TString Ite(TBool g, TString t, TString f);
 
         /// <summary>
         /// Check whether a boolean expression is satisfiable.

--- a/ZenLib/ModelChecking/ISolver.cs
+++ b/ZenLib/ModelChecking/ISolver.cs
@@ -89,7 +89,7 @@ namespace ZenLib.ModelChecking
         /// Create a new string expression.
         /// </summary>
         /// <param name="e">Zen arbitrary expr.</param>
-        /// <returns>The expression</returns>
+        /// <returns>The expression.</returns>
         (TVariable, TString) CreateStringVar(object e);
 
         /// <summary>

--- a/ZenLib/ModelChecking/InterleavingHeuristic.cs
+++ b/ZenLib/ModelChecking/InterleavingHeuristic.cs
@@ -196,7 +196,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenConcatExpr<T>(ZenConcatExpr<T> expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenConcatExpr(ZenConcatExpr expression, Unit parameter)
         {
             return LookupOrCompute(expression, () =>
             {

--- a/ZenLib/ModelChecking/InterleavingHeuristic.cs
+++ b/ZenLib/ModelChecking/InterleavingHeuristic.cs
@@ -180,7 +180,23 @@ namespace ZenLib.ModelChecking
             return emptySet;
         }
 
+        public ImmutableHashSet<object> VisitZenConstantStringExpr(ZenConstantStringExpr expression, Unit parameter)
+        {
+            return emptySet;
+        }
+
         public ImmutableHashSet<object> VisitZenSumExpr<T>(ZenSumExpr<T> expression, Unit parameter)
+        {
+            return LookupOrCompute(expression, () =>
+            {
+                var x = expression.Expr1.Accept(this, parameter);
+                var y = expression.Expr2.Accept(this, parameter);
+                this.Combine(x, y);
+                return x.Union(y);
+            });
+        }
+
+        public ImmutableHashSet<object> VisitZenConcatExpr<T>(ZenConcatExpr<T> expression, Unit parameter)
         {
             return LookupOrCompute(expression, () =>
             {

--- a/ZenLib/ModelChecking/ModelChecker.cs
+++ b/ZenLib/ModelChecking/ModelChecker.cs
@@ -14,15 +14,16 @@ namespace ZenLib.ModelChecking
     /// <typeparam name="TVar">The variable type.</typeparam>
     /// <typeparam name="TBool">The boolean expression type.</typeparam>
     /// <typeparam name="TInt">The integer expression type.</typeparam>
-    internal class ModelChecker<TModel, TVar, TBool, TInt> : IModelChecker
+    /// <typeparam name="TString">The integer expression type.</typeparam>
+    internal class ModelChecker<TModel, TVar, TBool, TInt, TString> : IModelChecker
     {
-        private ISolver<TModel, TVar, TBool, TInt> solver;
+        private ISolver<TModel, TVar, TBool, TInt, TString> solver;
 
         /// <summary>
-        /// Create an in instance of the <see cref="ModelChecker{TModel, TVar, TBool, TInt}"/> class.
+        /// Create an in instance of the <see cref="ModelChecker{TModel, TVar, TBool, TInt, TString}"/> class.
         /// </summary>
         /// <param name="solver">The solver.</param>
-        public ModelChecker(ISolver<TModel, TVar, TBool, TInt> solver)
+        public ModelChecker(ISolver<TModel, TVar, TBool, TInt, TString> solver)
         {
             this.solver = solver;
         }
@@ -37,10 +38,10 @@ namespace ZenLib.ModelChecking
         /// </returns>
         public Dictionary<object, object> ModelCheck(Zen<bool> expression)
         {
-            var symbolicEvaluator = new SymbolicEvaluationVisitor<TModel, TVar, TBool, TInt>(solver);
-            var env = new SymbolicEvaluationEnvironment<TModel, TVar, TBool, TInt>();
+            var symbolicEvaluator = new SymbolicEvaluationVisitor<TModel, TVar, TBool, TInt, TString>(solver);
+            var env = new SymbolicEvaluationEnvironment<TModel, TVar, TBool, TInt, TString>();
             var symbolicResult =
-                (SymbolicBool<TModel, TVar, TBool, TInt>)expression.Accept(symbolicEvaluator, env);
+                (SymbolicBool<TModel, TVar, TBool, TInt, TString>)expression.Accept(symbolicEvaluator, env);
 
             // Console.WriteLine($"[time] model checking: {watch.ElapsedMilliseconds}ms");
             // watch.Restart();

--- a/ZenLib/ModelChecking/ModelCheckerFactory.cs
+++ b/ZenLib/ModelChecking/ModelCheckerFactory.cs
@@ -40,7 +40,7 @@ namespace ZenLib.ModelChecking
             var manager = new DDManager<BDDNode>(new BDDNodeFactory());
             var solver = new SolverDD<BDDNode>(manager, mustInterleave);
             solver.Init();
-            return new ModelChecker<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>>(solver);
+            return new ModelChecker<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit>(solver);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace ZenLib.ModelChecking
         private static IModelChecker CreateModelCheckerZ3()
         {
             var solver = new SolverZ3();
-            return new ModelChecker<Model, Expr, BoolExpr, BitVecExpr>(solver);
+            return new ModelChecker<Model, Expr, BoolExpr, BitVecExpr, SeqExpr>(solver);
         }
     }
 }

--- a/ZenLib/ModelChecking/SolverDD.cs
+++ b/ZenLib/ModelChecking/SolverDD.cs
@@ -13,7 +13,7 @@ namespace ZenLib.ModelChecking
     /// Implementation of a solver using decision diagrams.
     /// </summary>
     /// <typeparam name="T">The diagram node type.</typeparam>
-    internal class SolverDD<T> : ISolver<Assignment<T>, Variable<T>, DD, BitVector<T>>
+    internal class SolverDD<T> : ISolver<Assignment<T>, Variable<T>, DD, BitVector<T>, Unit>
         where T : IDDNode
     {
         /// <summary>
@@ -219,9 +219,19 @@ namespace ZenLib.ModelChecking
             throw new ZenException("Decision diagram backend does not support multiplication");
         }
 
+        public Unit Concat(Unit x, Unit y)
+        {
+            throw new ZenException("Decision diagram backend does not support string operations. Use Z3 backend.");
+        }
+
         public DD Eq(BitVector<T> x, BitVector<T> y)
         {
             return this.Manager.Eq(x, y);
+        }
+
+        public DD Eq(Unit x, Unit y)
+        {
+            throw new ZenException("Decision diagram backend does not support string operations. Use Z3 backend.");
         }
 
         public DD LessThanOrEqual(BitVector<T> x, BitVector<T> y)
@@ -344,6 +354,16 @@ namespace ZenLib.ModelChecking
             return this.Manager.CreateBitvector(l);
         }
 
+        public (Variable<T>, Unit) CreateStringVar(object e)
+        {
+            throw new ZenException("Decision diagram backend does not support string operations. Use Z3 backend.");
+        }
+
+        public Unit CreateStringConst(string s)
+        {
+            throw new ZenException("Decision diagram backend does not support string operations. Use Z3 backend.");
+        }
+
         public object Get(Assignment<T> m, Variable<T> v)
         {
             if (v is VarBool<T> v1)
@@ -377,6 +397,11 @@ namespace ZenLib.ModelChecking
         public BitVector<T> Ite(DD g, BitVector<T> t, BitVector<T> f)
         {
             return this.Manager.Ite(g, t, f);
+        }
+
+        public Unit Ite(DD g, Unit t, Unit f)
+        {
+            throw new ZenException("Decision diagram backend does not support string operations. Use Z3 backend.");
         }
 
         public DD Not(DD x)

--- a/ZenLib/ModelChecking/SolverZ3.cs
+++ b/ZenLib/ModelChecking/SolverZ3.cs
@@ -268,6 +268,11 @@ namespace ZenLib.ModelChecking
                 return (int)uint.Parse(e.ToString());
             }
 
+            if (e.Sort == this.StringSort)
+            {
+                return e.ToString();
+            }
+
             if (long.TryParse(e.ToString(), out long xl))
             {
                 return xl;

--- a/ZenLib/ModelChecking/SolverZ3.cs
+++ b/ZenLib/ModelChecking/SolverZ3.cs
@@ -27,6 +27,8 @@ namespace ZenLib.ModelChecking
 
         private Sort LongSort;
 
+        private Sort StringSort;
+
         public SolverZ3()
         {
             this.nextIndex = 0;
@@ -42,6 +44,7 @@ namespace ZenLib.ModelChecking
             this.ShortSort = this.context.MkBitVecSort(16);
             this.IntSort = this.context.MkBitVecSort(32);
             this.LongSort = this.context.MkBitVecSort(64);
+            this.StringSort = this.context.StringSort;
         }
 
         private Symbol FreshSymbol()
@@ -131,14 +134,13 @@ namespace ZenLib.ModelChecking
 
         public SeqExpr CreateStringConst(string s)
         {
-            // TODO
-            throw new ZenException("Not yet implemented");
+            return this.context.MkString(s);
         }
 
         public (Expr, SeqExpr) CreateStringVar(object e)
         {
-            // TODO
-            throw new ZenException("Not yet implemented");
+            var v = this.context.MkConst(FreshSymbol(), this.StringSort);
+            return (v, (SeqExpr)v);
         }
 
         public BoolExpr Eq(BitVecExpr x, BitVecExpr y)
@@ -148,8 +150,7 @@ namespace ZenLib.ModelChecking
 
         public BoolExpr Eq(SeqExpr x, SeqExpr y)
         {
-            // TODO
-            throw new ZenException("Not yet implemented");
+            return this.context.MkEq(x, y);
         }
 
         public BoolExpr False()
@@ -185,8 +186,7 @@ namespace ZenLib.ModelChecking
 
         public SeqExpr Ite(BoolExpr g, SeqExpr t, SeqExpr f)
         {
-            // TODO
-            throw new ZenException("Not yet implemented");
+            return (SeqExpr)this.context.MkITE(g, t, f);
         }
 
         public BoolExpr LessThanOrEqual(BitVecExpr x, BitVecExpr y)
@@ -231,8 +231,7 @@ namespace ZenLib.ModelChecking
 
         public SeqExpr Concat(SeqExpr x, SeqExpr y)
         {
-            // TODO
-            throw new ZenException("Not yet implemented");
+            return this.context.MkConcat(x, y);
         }
 
         public object Get(Model m, Expr v)

--- a/ZenLib/ModelChecking/SolverZ3.cs
+++ b/ZenLib/ModelChecking/SolverZ3.cs
@@ -132,13 +132,13 @@ namespace ZenLib.ModelChecking
         public SeqExpr CreateStringConst(string s)
         {
             // TODO
-            throw new NotImplementedException();
+            throw new ZenException("Not yet implemented");
         }
 
         public (Expr, SeqExpr) CreateStringVar(object e)
         {
             // TODO
-            throw new NotImplementedException();
+            throw new ZenException("Not yet implemented");
         }
 
         public BoolExpr Eq(BitVecExpr x, BitVecExpr y)
@@ -149,7 +149,7 @@ namespace ZenLib.ModelChecking
         public BoolExpr Eq(SeqExpr x, SeqExpr y)
         {
             // TODO
-            throw new NotImplementedException();
+            throw new ZenException("Not yet implemented");
         }
 
         public BoolExpr False()
@@ -186,7 +186,7 @@ namespace ZenLib.ModelChecking
         public SeqExpr Ite(BoolExpr g, SeqExpr t, SeqExpr f)
         {
             // TODO
-            throw new NotImplementedException();
+            throw new ZenException("Not yet implemented");
         }
 
         public BoolExpr LessThanOrEqual(BitVecExpr x, BitVecExpr y)
@@ -232,7 +232,7 @@ namespace ZenLib.ModelChecking
         public SeqExpr Concat(SeqExpr x, SeqExpr y)
         {
             // TODO
-            throw new NotImplementedException();
+            throw new ZenException("Not yet implemented");
         }
 
         public object Get(Model m, Expr v)

--- a/ZenLib/ModelChecking/SolverZ3.cs
+++ b/ZenLib/ModelChecking/SolverZ3.cs
@@ -270,7 +270,8 @@ namespace ZenLib.ModelChecking
 
             if (e.Sort == this.StringSort)
             {
-                return e.ToString();
+                // Remove beginning and ending quotation marks
+                return e.ToString().Substring(1, e.ToString().Length - 2);
             }
 
             if (long.TryParse(e.ToString(), out long xl))

--- a/ZenLib/ModelChecking/SolverZ3.cs
+++ b/ZenLib/ModelChecking/SolverZ3.cs
@@ -9,7 +9,7 @@ namespace ZenLib.ModelChecking
     /// <summary>
     /// Zen solver based on the Z3 SMT solver.
     /// </summary>
-    internal class SolverZ3 : ISolver<Model, Expr, BoolExpr, BitVecExpr>
+    internal class SolverZ3 : ISolver<Model, Expr, BoolExpr, BitVecExpr, SeqExpr>
     {
         private Context context;
 
@@ -129,9 +129,27 @@ namespace ZenLib.ModelChecking
             return (v, (BitVecExpr)v);
         }
 
+        public SeqExpr CreateStringConst(string s)
+        {
+            // TODO
+            throw new NotImplementedException();
+        }
+
+        public (Expr, SeqExpr) CreateStringVar(object e)
+        {
+            // TODO
+            throw new NotImplementedException();
+        }
+
         public BoolExpr Eq(BitVecExpr x, BitVecExpr y)
         {
             return this.context.MkEq(x, y);
+        }
+
+        public BoolExpr Eq(SeqExpr x, SeqExpr y)
+        {
+            // TODO
+            throw new NotImplementedException();
         }
 
         public BoolExpr False()
@@ -163,6 +181,12 @@ namespace ZenLib.ModelChecking
             /* var v = (BitVecExpr)this.context.MkConst(FreshSymbol(), t.Sort);
             this.solver.Assert(this.context.MkEq(v, (BitVecExpr)this.context.MkITE(g, t, f)));
             return v; */
+        }
+
+        public SeqExpr Ite(BoolExpr g, SeqExpr t, SeqExpr f)
+        {
+            // TODO
+            throw new NotImplementedException();
         }
 
         public BoolExpr LessThanOrEqual(BitVecExpr x, BitVecExpr y)
@@ -203,6 +227,12 @@ namespace ZenLib.ModelChecking
         public BitVecExpr Multiply(BitVecExpr x, BitVecExpr y)
         {
             return this.context.MkBVMul(x, y);
+        }
+
+        public SeqExpr Concat(SeqExpr x, SeqExpr y)
+        {
+            // TODO
+            throw new NotImplementedException();
         }
 
         public object Get(Model m, Expr v)

--- a/ZenLib/ModelChecking/StateSetTransformer.cs
+++ b/ZenLib/ModelChecking/StateSetTransformer.cs
@@ -57,10 +57,10 @@ namespace ZenLib.ModelChecking
             if (invariant != null)
             {
                 var expr = invariant(this.zenInput, this.zenOutput);
-                var symbolicEvaluator = new SymbolicEvaluationVisitor<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>>(this.solver);
-                var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>>();
+                var symbolicEvaluator = new SymbolicEvaluationVisitor<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit>(this.solver);
+                var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit>();
                 var symbolicResult =
-                    (SymbolicBool<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>>)expr.Accept(symbolicEvaluator, env);
+                    (SymbolicBool<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit>)expr.Accept(symbolicEvaluator, env);
                 var ddOutput = symbolicResult.Value;
                 set = this.solver.And(set, ddOutput);
             }
@@ -93,10 +93,10 @@ namespace ZenLib.ModelChecking
             {
                 var expr = invariant(this.zenInput, this.zenOutput);
 
-                var symbolicEvaluator = new SymbolicEvaluationVisitor<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>>(this.solver);
-                var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>>();
+                var symbolicEvaluator = new SymbolicEvaluationVisitor<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit>(this.solver);
+                var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit>();
                 var symbolicResult =
-                    (SymbolicBool<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>>)expr.Accept(symbolicEvaluator, env);
+                    (SymbolicBool<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit>)expr.Accept(symbolicEvaluator, env);
                 var ddInput = symbolicResult.Value;
                 set = this.solver.And(set, ddInput);
             }

--- a/ZenLib/ModelChecking/SymbolicBool.cs
+++ b/ZenLib/ModelChecking/SymbolicBool.cs
@@ -9,20 +9,20 @@ namespace ZenLib.ModelChecking
     /// <summary>
     /// Representation of a symbolic boolean value.
     /// </summary>
-    internal class SymbolicBool<TModel, TVar, TBool, TInt> : SymbolicValue<TModel, TVar, TBool, TInt>
+    internal class SymbolicBool<TModel, TVar, TBool, TInt, TString> : SymbolicValue<TModel, TVar, TBool, TInt, TString>
     {
-        public SymbolicBool(ISolver<TModel, TVar, TBool, TInt> solver, TBool value) : base(solver)
+        public SymbolicBool(ISolver<TModel, TVar, TBool, TInt, TString> solver, TBool value) : base(solver)
         {
             this.Value = value;
         }
 
         public TBool Value { get; }
 
-        internal override SymbolicValue<TModel, TVar, TBool, TInt> Merge(TBool guard, SymbolicValue<TModel, TVar, TBool, TInt> other)
+        internal override SymbolicValue<TModel, TVar, TBool, TInt, TString> Merge(TBool guard, SymbolicValue<TModel, TVar, TBool, TInt, TString> other)
         {
-            var o = (SymbolicBool<TModel, TVar, TBool, TInt>)other;
+            var o = (SymbolicBool<TModel, TVar, TBool, TInt, TString>)other;
             var value = this.Solver.Ite(guard, this.Value, o.Value);
-            return new SymbolicBool<TModel, TVar, TBool, TInt>(this.Solver, value);
+            return new SymbolicBool<TModel, TVar, TBool, TInt, TString>(this.Solver, value);
         }
 
         /// <summary>

--- a/ZenLib/ModelChecking/SymbolicClass.cs
+++ b/ZenLib/ModelChecking/SymbolicClass.cs
@@ -11,9 +11,9 @@ namespace ZenLib.ModelChecking
     /// <summary>
     /// Representation of a symbolic boolean value.
     /// </summary>
-    internal class SymbolicClass<TModel, TVar, TBool, TInt> : SymbolicValue<TModel, TVar, TBool, TInt>
+    internal class SymbolicClass<TModel, TVar, TBool, TInt, TString> : SymbolicValue<TModel, TVar, TBool, TInt, TString>
     {
-        public SymbolicClass(ISolver<TModel, TVar, TBool, TInt> solver, ImmutableDictionary<string, SymbolicValue<TModel, TVar, TBool, TInt>> value) : base(solver)
+        public SymbolicClass(ISolver<TModel, TVar, TBool, TInt, TString> solver, ImmutableDictionary<string, SymbolicValue<TModel, TVar, TBool, TInt, TString>> value) : base(solver)
         {
             this.Fields = value;
         }
@@ -21,7 +21,7 @@ namespace ZenLib.ModelChecking
         /// <summary>
         /// Gets the underlying decision diagram bitvector representation.
         /// </summary>
-        public ImmutableDictionary<string, SymbolicValue<TModel, TVar, TBool, TInt>> Fields { get; set; }
+        public ImmutableDictionary<string, SymbolicValue<TModel, TVar, TBool, TInt, TString>> Fields { get; set; }
 
         /// <summary>
         /// Merge two symbolic integers together under a guard.
@@ -29,10 +29,10 @@ namespace ZenLib.ModelChecking
         /// <param name="guard">The guard.</param>
         /// <param name="other">The other integer.</param>
         /// <returns>A new symbolic integer.</returns>
-        internal override SymbolicValue<TModel, TVar, TBool, TInt> Merge(TBool guard, SymbolicValue<TModel, TVar, TBool, TInt> other)
+        internal override SymbolicValue<TModel, TVar, TBool, TInt, TString> Merge(TBool guard, SymbolicValue<TModel, TVar, TBool, TInt, TString> other)
         {
-            var o = (SymbolicClass<TModel, TVar, TBool, TInt>)other;
-            var newValue = ImmutableDictionary<string, SymbolicValue<TModel, TVar, TBool, TInt>>.Empty;
+            var o = (SymbolicClass<TModel, TVar, TBool, TInt, TString>)other;
+            var newValue = ImmutableDictionary<string, SymbolicValue<TModel, TVar, TBool, TInt, TString>>.Empty;
             foreach (var kv in this.Fields)
             {
                 var value1 = kv.Value;
@@ -40,7 +40,7 @@ namespace ZenLib.ModelChecking
                 newValue = newValue.Add(kv.Key, value1.Merge(guard, value2));
             }
 
-            return new SymbolicClass<TModel, TVar, TBool, TInt>(this.Solver, newValue);
+            return new SymbolicClass<TModel, TVar, TBool, TInt, TString>(this.Solver, newValue);
         }
 
         /// <summary>

--- a/ZenLib/ModelChecking/SymbolicEvaluationEnvironment.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluationEnvironment.cs
@@ -12,7 +12,7 @@ namespace ZenLib.ModelChecking
     internal class SymbolicEvaluationEnvironment<TModel, TVar, TBool, TInt, TString>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="SymbolicEvaluationEnvironment{TModel, TVar, TBool, TInt}"/> class.
+        /// Initializes a new instance of the <see cref="SymbolicEvaluationEnvironment{TModel, TVar, TBool, TInt, TString}"/> class.
         /// </summary>
         public SymbolicEvaluationEnvironment()
         {
@@ -20,7 +20,7 @@ namespace ZenLib.ModelChecking
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SymbolicEvaluationEnvironment{TModel, TVar, TBool, TInt}"/> class.
+        /// Initializes a new instance of the <see cref="SymbolicEvaluationEnvironment{TModel, TVar, TBool, TInt, TString}"/> class.
         /// </summary>
         /// <param name="argumentAssignment">The initial argument assignment.</param>
         public SymbolicEvaluationEnvironment(ImmutableDictionary<string, SymbolicValue<TModel, TVar, TBool, TInt, TString>> argumentAssignment)

--- a/ZenLib/ModelChecking/SymbolicEvaluationEnvironment.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluationEnvironment.cs
@@ -9,21 +9,21 @@ namespace ZenLib.ModelChecking
     /// <summary>
     /// An environment for the symbolic evaluator.
     /// </summary>
-    internal class SymbolicEvaluationEnvironment<TModel, TVar, TBool, TInt>
+    internal class SymbolicEvaluationEnvironment<TModel, TVar, TBool, TInt, TString>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SymbolicEvaluationEnvironment{TModel, TVar, TBool, TInt}"/> class.
         /// </summary>
         public SymbolicEvaluationEnvironment()
         {
-            this.ArgumentAssignment = ImmutableDictionary<string, SymbolicValue<TModel, TVar, TBool, TInt>>.Empty;
+            this.ArgumentAssignment = ImmutableDictionary<string, SymbolicValue<TModel, TVar, TBool, TInt, TString>>.Empty;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SymbolicEvaluationEnvironment{TModel, TVar, TBool, TInt}"/> class.
         /// </summary>
         /// <param name="argumentAssignment">The initial argument assignment.</param>
-        public SymbolicEvaluationEnvironment(ImmutableDictionary<string, SymbolicValue<TModel, TVar, TBool, TInt>> argumentAssignment)
+        public SymbolicEvaluationEnvironment(ImmutableDictionary<string, SymbolicValue<TModel, TVar, TBool, TInt, TString>> argumentAssignment)
         {
             this.ArgumentAssignment = argumentAssignment;
         }
@@ -31,6 +31,6 @@ namespace ZenLib.ModelChecking
         /// <summary>
         /// Gets the argument assignment.
         /// </summary>
-        public ImmutableDictionary<string, SymbolicValue<TModel, TVar, TBool, TInt>> ArgumentAssignment { get; }
+        public ImmutableDictionary<string, SymbolicValue<TModel, TVar, TBool, TInt, TString>> ArgumentAssignment { get; }
     }
 }

--- a/ZenLib/ModelChecking/SymbolicEvaluationVisitor.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluationVisitor.cs
@@ -400,7 +400,7 @@ namespace ZenLib.ModelChecking
 
                 if (v1 is SymbolicString<TModel, TVar, TBool, TInt, TString> s1 && v2 is SymbolicString<TModel, TVar, TBool, TInt, TString> s2)
                 {
-                    return new SymbolicString<TModel, TVar, TBool, TInt, TString>(this.Solver, this.Solver.Eq(s1.Value, s2.Value));
+                    return new SymbolicBool<TModel, TVar, TBool, TInt, TString>(this.Solver, this.Solver.Eq(s1.Value, s2.Value));
                 }
 
                 var i1 = (SymbolicInteger<TModel, TVar, TBool, TInt, TString>)v1;

--- a/ZenLib/ModelChecking/SymbolicEvaluationVisitor.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluationVisitor.cs
@@ -137,6 +137,15 @@ namespace ZenLib.ModelChecking
                     return result;
                 }
 
+                if (type == ReflectionUtilities.StringType)
+                {
+                    var (variable, expr) = this.Solver.CreateStringVar(expression);
+                    this.Variables.Add(variable);
+                    var result = new SymbolicString<TModel, TVar, TBool, TInt, TString>(this.Solver, expr);
+                    this.ArbitraryVariables[expression] = variable;
+                    return result;
+                }
+
                 // long or ulong
                 var (v, e) = this.Solver.CreateLongVar(expression);
                 this.Variables.Add(v);

--- a/ZenLib/ModelChecking/SymbolicEvaluationVisitor.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluationVisitor.cs
@@ -36,7 +36,7 @@ namespace ZenLib.ModelChecking
         private Dictionary<object, SymbolicValue<TModel, TVar, TBool, TInt, TString>> Cache { get; } = new Dictionary<object, SymbolicValue<TModel, TVar, TBool, TInt, TString>>();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SymbolicEvaluationVisitor{TModel, TVar, TBool, TInt}"/> class.
+        /// Initializes a new instance of the <see cref="SymbolicEvaluationVisitor{TModel, TVar, TBool, TInt, TString}"/> class.
         /// </summary>
         /// <param name="solver">The manager object.</param>
         public SymbolicEvaluationVisitor(ISolver<TModel, TVar, TBool, TInt, TString> solver)

--- a/ZenLib/ModelChecking/SymbolicEvaluationVisitor.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluationVisitor.cs
@@ -684,7 +684,7 @@ namespace ZenLib.ModelChecking
         /// <param name="expression">The expression.</param>
         /// <param name="parameter">The parameter.</param>
         /// <returns>The resulting symbolic value.</returns>
-        public SymbolicValue<TModel, TVar, TBool, TInt, TString> VisitZenConcatExpr<T1>(ZenConcatExpr<T1> expression, SymbolicEvaluationEnvironment<TModel, TVar, TBool, TInt, TString> parameter)
+        public SymbolicValue<TModel, TVar, TBool, TInt, TString> VisitZenConcatExpr(ZenConcatExpr expression, SymbolicEvaluationEnvironment<TModel, TVar, TBool, TInt, TString> parameter)
         {
             return LookupOrCompute(expression, () =>
             {

--- a/ZenLib/ModelChecking/SymbolicEvaluationVisitor.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluationVisitor.cs
@@ -344,6 +344,21 @@ namespace ZenLib.ModelChecking
         }
 
         /// <summary>
+        /// Visit a ConstantStringExpr.
+        /// </summary>
+        /// <param name="expression">The expression.</param>
+        /// <param name="parameter">The parameter.</param>
+        /// <returns>The resulting symbolic value.</returns>
+        public SymbolicValue<TModel, TVar, TBool, TInt, TString> VisitZenConstantStringExpr(ZenConstantStringExpr expression, SymbolicEvaluationEnvironment<TModel, TVar, TBool, TInt, TString> parameter)
+        {
+            return LookupOrCompute(expression, () =>
+            {
+                var bv = this.Solver.CreateStringConst((string)expression.Value);
+                return new SymbolicString<TModel, TVar, TBool, TInt, TString>(this.Solver, bv);
+            });
+        }
+
+        /// <summary>
         /// Visit a CreateObjectExpr.
         /// </summary>
         /// <param name="expression">The expression.</param>
@@ -381,6 +396,11 @@ namespace ZenLib.ModelChecking
                 if (v1 is SymbolicBool<TModel, TVar, TBool, TInt, TString> b1 && v2 is SymbolicBool<TModel, TVar, TBool, TInt, TString> b2)
                 {
                     return new SymbolicBool<TModel, TVar, TBool, TInt, TString>(this.Solver, this.Solver.Iff(b1.Value, b2.Value));
+                }
+
+                if (v1 is SymbolicString<TModel, TVar, TBool, TInt, TString> s1 && v2 is SymbolicString<TModel, TVar, TBool, TInt, TString> s2)
+                {
+                    return new SymbolicString<TModel, TVar, TBool, TInt, TString>(this.Solver, this.Solver.Eq(s1.Value, s2.Value));
                 }
 
                 var i1 = (SymbolicInteger<TModel, TVar, TBool, TInt, TString>)v1;
@@ -646,6 +666,22 @@ namespace ZenLib.ModelChecking
                 var v1 = (SymbolicInteger<TModel, TVar, TBool, TInt, TString>)expression.Expr1.Accept(this, parameter);
                 var v2 = (SymbolicInteger<TModel, TVar, TBool, TInt, TString>)expression.Expr2.Accept(this, parameter);
                 return new SymbolicInteger<TModel, TVar, TBool, TInt, TString>(this.Solver, this.Solver.Add(v1.Value, v2.Value));
+            });
+        }
+
+        /// <summary>
+        /// Visit a ConcatExpr.
+        /// </summary>
+        /// <param name="expression">The expression.</param>
+        /// <param name="parameter">The parameter.</param>
+        /// <returns>The resulting symbolic value.</returns>
+        public SymbolicValue<TModel, TVar, TBool, TInt, TString> VisitZenConcatExpr<T1>(ZenConcatExpr<T1> expression, SymbolicEvaluationEnvironment<TModel, TVar, TBool, TInt, TString> parameter)
+        {
+            return LookupOrCompute(expression, () =>
+            {
+                var v1 = (SymbolicString<TModel, TVar, TBool, TInt, TString>)expression.Expr1.Accept(this, parameter);
+                var v2 = (SymbolicString<TModel, TVar, TBool, TInt, TString>)expression.Expr2.Accept(this, parameter);
+                return new SymbolicString<TModel, TVar, TBool, TInt, TString>(this.Solver, this.Solver.Concat(v1.Value, v2.Value));
             });
         }
 

--- a/ZenLib/ModelChecking/SymbolicEvaluator.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluator.cs
@@ -282,7 +282,7 @@ namespace ZenLib.ModelChecking
                 zenExprToVariable[zenExpr] = v;
             }
 
-            if (zenExpr is Zen<long> || zenExpr is Zen<long>)
+            if (zenExpr is Zen<long> || zenExpr is Zen<ulong>)
             {
                 var (v, _) = solver.CreateLongVar(zenExpr);
                 zenExprToVariable[zenExpr] = v;

--- a/ZenLib/ModelChecking/SymbolicEvaluator.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluator.cs
@@ -192,10 +192,10 @@ namespace ZenLib.ModelChecking
 
             // get the decision diagram representing the equality.
             var symbolicEvaluator =
-                new SymbolicEvaluationVisitor<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>>(solver);
-            var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>>();
+                new SymbolicEvaluationVisitor<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit>(solver);
+            var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit>();
             var symbolicValue = newExpression.Accept(symbolicEvaluator, env);
-            var symbolicResult = (SymbolicBool<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>>)symbolicValue;
+            var symbolicResult = (SymbolicBool<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit>)symbolicValue;
 
             DD result = (DD)(object)symbolicResult.Value;
 

--- a/ZenLib/ModelChecking/SymbolicEvaluator.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluator.cs
@@ -287,6 +287,12 @@ namespace ZenLib.ModelChecking
                 var (v, _) = solver.CreateLongVar(zenExpr);
                 zenExprToVariable[zenExpr] = v;
             }
+
+            if (zenExpr is Zen<string>)
+            {
+                var (v, _) = solver.CreateStringVar(zenExpr);
+                zenExprToVariable[zenExpr] = v;
+            }
         }
     }
 }

--- a/ZenLib/ModelChecking/SymbolicInteger.cs
+++ b/ZenLib/ModelChecking/SymbolicInteger.cs
@@ -9,20 +9,20 @@ namespace ZenLib.ModelChecking
     /// <summary>
     /// Representation of a symbolic boolean value.
     /// </summary>
-    internal class SymbolicInteger<TModel, TVar, TBool, TInt> : SymbolicValue<TModel, TVar, TBool, TInt>
+    internal class SymbolicInteger<TModel, TVar, TBool, TInt, TString> : SymbolicValue<TModel, TVar, TBool, TInt, TString>
     {
-        public SymbolicInteger(ISolver<TModel, TVar, TBool, TInt> solver, TInt value) : base(solver)
+        public SymbolicInteger(ISolver<TModel, TVar, TBool, TInt, TString> solver, TInt value) : base(solver)
         {
             this.Value = value;
         }
 
         public TInt Value { get; }
 
-        internal override SymbolicValue<TModel, TVar, TBool, TInt> Merge(TBool guard, SymbolicValue<TModel, TVar, TBool, TInt> other)
+        internal override SymbolicValue<TModel, TVar, TBool, TInt, TString> Merge(TBool guard, SymbolicValue<TModel, TVar, TBool, TInt, TString> other)
         {
-            var o = (SymbolicInteger<TModel, TVar, TBool, TInt>)other;
+            var o = (SymbolicInteger<TModel, TVar, TBool, TInt, TString>)other;
             var value = this.Solver.Ite(guard, this.Value, o.Value);
-            return new SymbolicInteger<TModel, TVar, TBool, TInt>(this.Solver, value);
+            return new SymbolicInteger<TModel, TVar, TBool, TInt, TString>(this.Solver, value);
         }
 
         /// <summary>

--- a/ZenLib/ModelChecking/SymbolicList.cs
+++ b/ZenLib/ModelChecking/SymbolicList.cs
@@ -11,9 +11,9 @@ namespace ZenLib.ModelChecking
     /// <summary>
     /// Representation of a symbolic boolean value.
     /// </summary>
-    internal class SymbolicList<TModel, TVar, TBool, TInt> : SymbolicValue<TModel, TVar, TBool, TInt>
+    internal class SymbolicList<TModel, TVar, TBool, TInt, TString> : SymbolicValue<TModel, TVar, TBool, TInt, TString>
     {
-        public SymbolicList(ISolver<TModel, TVar, TBool, TInt> solver, GuardedListGroup<TModel, TVar, TBool, TInt> value) : base(solver)
+        public SymbolicList(ISolver<TModel, TVar, TBool, TInt, TString> solver, GuardedListGroup<TModel, TVar, TBool, TInt, TString> value) : base(solver)
         {
             this.GuardedListGroup = value;
         }
@@ -21,7 +21,7 @@ namespace ZenLib.ModelChecking
         /// <summary>
         /// Gets the guarded lists representing the symbolic list.
         /// </summary>
-        public GuardedListGroup<TModel, TVar, TBool, TInt> GuardedListGroup { get; }
+        public GuardedListGroup<TModel, TVar, TBool, TInt, TString> GuardedListGroup { get; }
 
         /// <summary>
         /// Merge two symbolic lists together under a guard.
@@ -29,11 +29,11 @@ namespace ZenLib.ModelChecking
         /// <param name="guard">The guard.</param>
         /// <param name="other">The other list.</param>
         /// <returns>A new symbolic list.</returns>
-        internal override SymbolicValue<TModel, TVar, TBool, TInt> Merge(TBool guard, SymbolicValue<TModel, TVar, TBool, TInt> other)
+        internal override SymbolicValue<TModel, TVar, TBool, TInt, TString> Merge(TBool guard, SymbolicValue<TModel, TVar, TBool, TInt, TString> other)
         {
-            var o = (SymbolicList<TModel, TVar, TBool, TInt>)other;
+            var o = (SymbolicList<TModel, TVar, TBool, TInt, TString>)other;
             var result = Merge(guard, this.GuardedListGroup, o.GuardedListGroup);
-            return new SymbolicList<TModel, TVar, TBool, TInt>(this.Solver, result);
+            return new SymbolicList<TModel, TVar, TBool, TInt, TString>(this.Solver, result);
         }
 
         /// <summary>
@@ -43,10 +43,10 @@ namespace ZenLib.ModelChecking
         /// <param name="lists1">The first lists.</param>
         /// <param name="lists2">The second lists.</param>
         /// <returns>A new guarded group of lists.</returns>
-        private GuardedListGroup<TModel, TVar, TBool, TInt> Merge(
+        private GuardedListGroup<TModel, TVar, TBool, TInt, TString> Merge(
             TBool guard,
-            GuardedListGroup<TModel, TVar, TBool, TInt> lists1,
-            GuardedListGroup<TModel, TVar, TBool, TInt> lists2)
+            GuardedListGroup<TModel, TVar, TBool, TInt, TString> lists1,
+            GuardedListGroup<TModel, TVar, TBool, TInt, TString> lists2)
         {
             var result = CommonUtilities.Merge(lists1.Mapping, lists2.Mapping, (len, list1, list2) =>
             {
@@ -66,13 +66,13 @@ namespace ZenLib.ModelChecking
 
                 /* if (merged.Guard.Equals(this.Solver.False()))
                 {
-                    return Option.None<GuardedList<TModel, TVar, TBool, TInt>>();
+                    return Option.None<GuardedList<TModel, TVar, TBool, TInt, TString>>();
                 } */
 
                 return Option.Some(merged);
             });
 
-            return new GuardedListGroup<TModel, TVar, TBool, TInt>(result);
+            return new GuardedListGroup<TModel, TVar, TBool, TInt, TString>(result);
         }
 
         /// <summary>
@@ -81,10 +81,10 @@ namespace ZenLib.ModelChecking
         /// <param name="guard">The guard.</param>
         /// <param name="list">The list.</param>
         /// <returns></returns>
-        private GuardedList<TModel, TVar, TBool, TInt> MapGuard(TBool guard, GuardedList<TModel, TVar, TBool, TInt> list)
+        private GuardedList<TModel, TVar, TBool, TInt, TString> MapGuard(TBool guard, GuardedList<TModel, TVar, TBool, TInt, TString> list)
         {
             var newGuard = this.Solver.And(guard, list.Guard);
-            return new GuardedList<TModel, TVar, TBool, TInt>(newGuard, list.Values);
+            return new GuardedList<TModel, TVar, TBool, TInt, TString>(newGuard, list.Values);
         }
 
         /// <summary>
@@ -94,13 +94,13 @@ namespace ZenLib.ModelChecking
         /// <param name="list1">The first list.</param>
         /// <param name="list2">The second list.</param>
         /// <returns></returns>
-        private GuardedList<TModel, TVar, TBool, TInt> Merge(
+        private GuardedList<TModel, TVar, TBool, TInt, TString> Merge(
             TBool guard,
-            GuardedList<TModel, TVar, TBool, TInt> list1,
-            GuardedList<TModel, TVar, TBool, TInt> list2)
+            GuardedList<TModel, TVar, TBool, TInt, TString> list1,
+            GuardedList<TModel, TVar, TBool, TInt, TString> list2)
         {
             var newGuard = this.Solver.Ite(guard, list1.Guard, list2.Guard);
-            var newValues = ImmutableList<SymbolicValue<TModel, TVar, TBool, TInt>>.Empty;
+            var newValues = ImmutableList<SymbolicValue<TModel, TVar, TBool, TInt, TString>>.Empty;
             for (int i = 0; i < list1.Values.Count; i++)
             {
                 var v1 = list1.Values[i];
@@ -108,7 +108,7 @@ namespace ZenLib.ModelChecking
                 newValues = newValues.Add(v1.Merge(guard, v2));
             }
 
-            return new GuardedList<TModel, TVar, TBool, TInt>(newGuard, newValues);
+            return new GuardedList<TModel, TVar, TBool, TInt, TString>(newGuard, newValues);
         }
 
         /// <summary>
@@ -125,14 +125,14 @@ namespace ZenLib.ModelChecking
     /// <summary>
     /// Represents a guarded group of lists, distinguishing by length.
     /// </summary>
-    internal class GuardedListGroup<TModel, TVar, TBool, TInt>
+    internal class GuardedListGroup<TModel, TVar, TBool, TInt, TString>
     {
-        public GuardedListGroup(ImmutableDictionary<int, GuardedList<TModel, TVar, TBool, TInt>> mapping)
+        public GuardedListGroup(ImmutableDictionary<int, GuardedList<TModel, TVar, TBool, TInt, TString>> mapping)
         {
             this.Mapping = mapping;
         }
 
-        public ImmutableDictionary<int, GuardedList<TModel, TVar, TBool, TInt>> Mapping { get; }
+        public ImmutableDictionary<int, GuardedList<TModel, TVar, TBool, TInt, TString>> Mapping { get; }
 
         /// <summary>
         /// Convert the object to a string.
@@ -156,9 +156,9 @@ namespace ZenLib.ModelChecking
     /// <summary>
     /// A single list with a fixed length guarded by a predicate.
     /// </summary>
-    internal class GuardedList<TModel, TVar, TBool, TInt>
+    internal class GuardedList<TModel, TVar, TBool, TInt, TString>
     {
-        public GuardedList(TBool guard, ImmutableList<SymbolicValue<TModel, TVar, TBool, TInt>> values)
+        public GuardedList(TBool guard, ImmutableList<SymbolicValue<TModel, TVar, TBool, TInt, TString>> values)
         {
             this.Guard = guard;
             this.Values = values;
@@ -166,7 +166,7 @@ namespace ZenLib.ModelChecking
 
         public TBool Guard { get; }
 
-        public ImmutableList<SymbolicValue<TModel, TVar, TBool, TInt>> Values { get; }
+        public ImmutableList<SymbolicValue<TModel, TVar, TBool, TInt, TString>> Values { get; }
 
         /// <summary>
         /// Convert the object to a string.

--- a/ZenLib/ModelChecking/SymbolicString.cs
+++ b/ZenLib/ModelChecking/SymbolicString.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="SymbolicInteger.cs" company="Microsoft">
+// <copyright file="SymbolicString.cs" company="Microsoft">
 // Copyright (c) Microsoft. All rights reserved.
 // </copyright>
 
@@ -7,22 +7,22 @@ namespace ZenLib.ModelChecking
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
-    /// Representation of a symbolic integer value.
+    /// Representation of a symbolic string value.
     /// </summary>
-    internal class SymbolicInteger<TModel, TVar, TBool, TInt, TString> : SymbolicValue<TModel, TVar, TBool, TInt, TString>
+    internal class SymbolicString<TModel, TVar, TBool, TInt, TString> : SymbolicValue<TModel, TVar, TBool, TInt, TString>
     {
-        public SymbolicInteger(ISolver<TModel, TVar, TBool, TInt, TString> solver, TInt value) : base(solver)
+        public SymbolicString(ISolver<TModel, TVar, TBool, TInt, TString> solver, TString value) : base(solver)
         {
             this.Value = value;
         }
 
-        public TInt Value { get; }
+        public TString Value { get; }
 
         internal override SymbolicValue<TModel, TVar, TBool, TInt, TString> Merge(TBool guard, SymbolicValue<TModel, TVar, TBool, TInt, TString> other)
         {
-            var o = (SymbolicInteger<TModel, TVar, TBool, TInt, TString>)other;
+            var o = (SymbolicString<TModel, TVar, TBool, TInt, TString>)other;
             var value = this.Solver.Ite(guard, this.Value, o.Value);
-            return new SymbolicInteger<TModel, TVar, TBool, TInt, TString>(this.Solver, value);
+            return new SymbolicString<TModel, TVar, TBool, TInt, TString>(this.Solver, value);
         }
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace ZenLib.ModelChecking
         [ExcludeFromCodeCoverage]
         public override string ToString()
         {
-            return "<symint>";
+            return "<symstring>";
         }
     }
 }

--- a/ZenLib/ModelChecking/SymbolicValue.cs
+++ b/ZenLib/ModelChecking/SymbolicValue.cs
@@ -7,17 +7,17 @@ namespace ZenLib.ModelChecking
     /// <summary>
     /// Representation of a symbolic value.
     /// </summary>
-    internal abstract class SymbolicValue<TModel, TVar, TBool, TInt>
+    internal abstract class SymbolicValue<TModel, TVar, TBool, TInt, TString>
     {
-        public ISolver<TModel, TVar, TBool, TInt> Solver;
+        public ISolver<TModel, TVar, TBool, TInt, TString> Solver;
 
-        public SymbolicValue(ISolver<TModel, TVar, TBool, TInt> solver)
+        public SymbolicValue(ISolver<TModel, TVar, TBool, TInt, TString> solver)
         {
             this.Solver = solver;
         }
 
-        internal abstract SymbolicValue<TModel, TVar, TBool, TInt> Merge(
+        internal abstract SymbolicValue<TModel, TVar, TBool, TInt, TString> Merge(
             TBool guard,
-            SymbolicValue<TModel, TVar, TBool, TInt> other);
+            SymbolicValue<TModel, TVar, TBool, TInt, TString> other);
     }
 }

--- a/ZenLib/ReflectionUtilities.cs
+++ b/ZenLib/ReflectionUtilities.cs
@@ -525,6 +525,22 @@ namespace ZenLib
         }
 
         /// <summary>
+        /// Get a constant string value.
+        /// </summary>
+        /// <typeparam name="T">The type.</typeparam>
+        /// <param name="value">The Zen string value.</param>
+        /// <returns>A string.</returns>
+        public static string GetConstantString<T>(Zen<T> value)
+        {
+            if (value is ZenConstantStringExpr xs)
+            {
+                return (string)xs.Value;
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Create a constant Zen integer value.
         /// </summary>
         /// <typeparam name="T">The integer gype.</typeparam>
@@ -564,6 +580,16 @@ namespace ZenLib
             }
 
             return (Zen<T>)(object)ZenConstantUlongExpr.Create((ulong)value);
+        }
+
+        /// <summary>
+        /// Create a constant Zen string value.
+        /// </summary>
+        /// <param name="value">The Zen string value.</param>
+        /// <returns>A string.</returns>
+        public static Zen<string> CreateConstantString(string value)
+        {
+            return (Zen<string>)(object)ZenConstantStringExpr.Create(value);
         }
 
         /// <summary>

--- a/ZenLib/ReflectionUtilities.cs
+++ b/ZenLib/ReflectionUtilities.cs
@@ -587,9 +587,9 @@ namespace ZenLib
         /// </summary>
         /// <param name="value">The Zen string value.</param>
         /// <returns>A string.</returns>
-        public static Zen<T> CreateConstantString<T>(string value)
+        public static Zen<string> CreateConstantString(string value)
         {
-            return (Zen<T>)(object)ZenConstantStringExpr.Create(value);
+            return (Zen<string>)(object)ZenConstantStringExpr.Create(value);
         }
 
         /// <summary>

--- a/ZenLib/ReflectionUtilities.cs
+++ b/ZenLib/ReflectionUtilities.cs
@@ -350,10 +350,10 @@ namespace ZenLib
                 return obj;
             }
 
-            /* if (type == typeof(string))
+            if (type == typeof(string))
             {
-                return string.Copy((string)obj);
-            } */
+                return String.Copy((string)obj);
+            }
 
             var result = Activator.CreateInstance(type);
             foreach (var fieldInfo in GetAllFields(type))
@@ -416,6 +416,11 @@ namespace ZenLib
             if (type == UlongType)
             {
                 return visitor.VisitUlong();
+            }
+
+            if (type == StringType)
+            {
+                return visitor.VisitString();
             }
 
             if (IsOptionType(type))

--- a/ZenLib/ReflectionUtilities.cs
+++ b/ZenLib/ReflectionUtilities.cs
@@ -587,9 +587,9 @@ namespace ZenLib
         /// </summary>
         /// <param name="value">The Zen string value.</param>
         /// <returns>A string.</returns>
-        public static Zen<string> CreateConstantString(string value)
+        public static Zen<T> CreateConstantString<T>(string value)
         {
-            return (Zen<string>)(object)ZenConstantStringExpr.Create(value);
+            return (Zen<T>)(object)ZenConstantStringExpr.Create(value);
         }
 
         /// <summary>

--- a/ZenLib/ZenLib.csproj
+++ b/ZenLib/ZenLib.csproj
@@ -36,5 +36,5 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-  </ItemGroup> 
+  </ItemGroup>
 </Project>

--- a/ZenLibTests/SimplifierTests.cs
+++ b/ZenLibTests/SimplifierTests.cs
@@ -177,6 +177,18 @@ namespace ZenLib.Tests
         }
 
         /// <summary>
+        /// Simplify for concatenaion.
+        /// </summary>
+        [TestMethod]
+        public void TestConcatenationSimplification()
+        {
+            Assert.AreEqual(String("hello") + String(""), String("hello"));
+            Assert.AreEqual(String("a") + String("hello"), String("ahello"));
+            CheckValid<string>(x => x + "" == x);
+            CheckValid<string>(x => "" + x == x);
+        }
+
+        /// <summary>
         /// Simplify if conditions.
         /// </summary>
         [TestMethod]

--- a/ZenLibTests/StringTests.cs
+++ b/ZenLibTests/StringTests.cs
@@ -85,17 +85,6 @@ namespace ZenLib.Tests
         /// Test equality for composite types.
         /// </summary>
         [TestMethod]
-        public void TestStringEqualityComposite()
-        {
-            CheckAgreement<(string, string), (string, string)>((x, y) => x == y);
-            CheckAgreement<Tuple<string, string>, Tuple<string, string>>((x, y) => x == y);
-            CheckAgreement<Option<string>, Option<string>>((x, y) => x == y);
-        }
-
-        /// <summary>
-        /// Test equality for composite types.
-        /// </summary>
-        [TestMethod]
         [ExpectedException(typeof(ZenException))]
         public void TestStringEqualityCompositeException1()
         {

--- a/ZenLibTests/StringTests.cs
+++ b/ZenLibTests/StringTests.cs
@@ -1,0 +1,145 @@
+// <copyright file="StringTests.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace ZenLib.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using ZenLib;
+    using ZenLib.Tests.Model;
+    using static ZenLib.Language;
+    using static ZenLib.Tests.TestHelper;
+
+    /// <summary>
+    /// Tests for the string type.
+    /// </summary>
+    [TestClass]
+    [ExcludeFromCodeCoverage]
+    public class StringTests
+    {
+        /// <summary>
+        /// Test concatenation with empty string.
+        /// </summary>
+        [TestMethod]
+        public void TestConcatIdentity()
+        {
+            CheckValid<string>(x => x + "" == x);
+        }
+
+        /// <summary>
+        /// Test string concatenation is associative.
+        /// </summary>
+        [TestMethod]
+        public void TestConcatAssociative()
+        {
+            CheckValid<string, string, string>((x, y, z) => (x + y) + z == x + (y + z));
+        }
+
+        /// <summary>
+        /// Test concat twice.
+        /// </summary>
+        [TestMethod]
+        public void TestConcatTwice()
+        {
+            CheckAgreement<string>(x => x + x == "hello");
+        }
+
+        /// <summary>
+        /// Test concatenating multiple values is solved correctly.
+        /// </summary>
+        [TestMethod]
+        public void TestConcatMultipleValues()
+        {
+            var f1 = Function<string, string, bool>((w, x) => w + x == "hello");
+            var f2 = Function<string, string, string, bool>((w, x, y) => w + x + y == "hello");
+            var f3 = Function<string, string, string, string, bool>((w, x, y, z) => w + x + y + z == "hello");
+            var r1 = f1.Find((i1, i2, o) => o);
+            var r2 = f2.Find((i1, i2, i3, o) => o);
+            var r3 = f3.Find((i1, i2, i3, i4, o) => o);
+
+            Assert.IsTrue(r1.HasValue);
+            Assert.IsTrue(r2.HasValue);
+            Assert.IsTrue(r3.HasValue);
+
+            string s1 = (string)r1.Value.Item1 + (string)r1.Value.Item2;
+            string s2 = (string)r2.Value.Item1 + (string)r2.Value.Item2 + (string)r2.Value.Item3;
+            string s3 = (string)r3.Value.Item1 + (string)r3.Value.Item2 + (string)r3.Value.Item3 + (string)r3.Value.Item4;
+            Assert.AreEqual("hello", s1);
+            Assert.AreEqual("hello", s2);
+            Assert.AreEqual("hello", s3);
+
+            Assert.IsTrue(f1.Evaluate("he", "llo"));
+            Assert.IsFalse(f1.Evaluate("he", "ello"));
+
+            Assert.IsTrue(f2.Evaluate("h", "e", "llo"));
+            Assert.IsFalse(f2.Evaluate("hell", "l", "o"));
+
+            Assert.IsTrue(f3.Evaluate("h", "e", "ll", "o"));
+            Assert.IsFalse(f3.Evaluate("hel", "l", "l", "o"));
+        }
+
+        /// <summary>
+        /// Test equality for composite types.
+        /// </summary>
+        [TestMethod]
+        public void TestStringEqualityComposite()
+        {
+            CheckAgreement<(string, string), (string, string)>((x, y) => x == y);
+            CheckAgreement<Tuple<string, string>, Tuple<string, string>>((x, y) => x == y);
+            CheckAgreement<Option<string>, Option<string>>((x, y) => x == y);
+        }
+
+        /// <summary>
+        /// Test equality for composite types.
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(ZenException))]
+        public void TestStringEqualityCompositeException1()
+        {
+            CheckAgreement<IList<string>, IList<string>>((l1, l2) => l1 == l2);
+        }
+
+        /// <summary>
+        /// Test equality for composite types.
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(ZenException))]
+        public void TestStringEqualityCompositeException2()
+        {
+            CheckAgreement<IDictionary<string, string>, IDictionary<string, string>>((l1, l2) => l1 == l2);
+        }
+
+        /// <summary>
+        /// Test equality for composite types.
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(ZenException))]
+        public void TestStringEqualityCompositeException3()
+        {
+            CheckAgreement<Option<IList<string>>, Option<IList<string>>>((l1, l2) => l1 == l2);
+        }
+
+        /// <summary>
+        /// Test equality for composite types.
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(ZenException))]
+        public void TestStringEqualityCompositeException4()
+        {
+            CheckAgreement<(string, IList<string>), (string, IList<string>)>((l1, l2) => l1 == l2);
+        }
+
+        /// <summary>
+        /// Test an exception is thrown for non-strings.
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TestConcatException()
+        {
+            _ = EmptyList<string>() + EmptyList<string>();
+        }
+    }
+}

--- a/ZenLibTests/TestHelper.cs
+++ b/ZenLibTests/TestHelper.cs
@@ -39,6 +39,15 @@ namespace ZenLib.Tests
         };
 
         /// <summary>
+        /// Backends to test when running string tests.
+        /// </summary>
+        private static TestParameter[] stringParameters = new TestParameter[]
+        {
+            new TestParameter { Backend = Backend.Z3, Simplify = true, ListSize = 5 },
+            new TestParameter { Backend = Backend.Z3, Simplify = false, ListSize = 5 },
+        };
+
+        /// <summary>
         /// Repeat an action multiple times.
         /// </summary>
         /// <param name="action">The action.</param>
@@ -68,7 +77,13 @@ namespace ZenLib.Tests
         /// <param name="function">The predicate.</param>
         public static void CheckValid<T1>(Func<Zen<T1>, Zen<bool>> function)
         {
-            foreach (var p in parameters)
+            // If testing on strings, only use Z3 backend (DD does not support strings)
+            TestParameter[] selectedParams = parameters;
+            if (typeof(T1) == ReflectionUtilities.StringType)
+            {
+                selectedParams = stringParameters;
+            }
+            foreach (var p in selectedParams)
             {
                 Start(p);
 
@@ -97,7 +112,14 @@ namespace ZenLib.Tests
         /// <param name="function">The predicate.</param>
         public static void CheckValid<T1, T2>(Func<Zen<T1>, Zen<T2>, Zen<bool>> function)
         {
-            foreach (var p in parameters)
+            // If testing on strings, only use Z3 backend (DD does not support strings)
+            TestParameter[] selectedParams = parameters;
+            if (typeof(T1) == ReflectionUtilities.StringType
+             || typeof(T2) == ReflectionUtilities.StringType)
+            {
+                selectedParams = stringParameters;
+            }
+            foreach (var p in selectedParams)
             {
                 Start(p);
 
@@ -127,7 +149,15 @@ namespace ZenLib.Tests
         /// <param name="function">The predicate.</param>
         public static void CheckValid<T1, T2, T3>(Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<bool>> function)
         {
-            foreach (var p in parameters)
+            // If testing on strings, only use Z3 backend (DD does not support strings)
+            TestParameter[] selectedParams = parameters;
+            if (typeof(T1) == ReflectionUtilities.StringType
+             || typeof(T2) == ReflectionUtilities.StringType
+             || typeof(T3) == ReflectionUtilities.StringType)
+            {
+                selectedParams = stringParameters;
+            }
+            foreach (var p in selectedParams)
             {
                 Start(p);
 
@@ -158,7 +188,16 @@ namespace ZenLib.Tests
         /// <param name="function">The predicate.</param>
         public static void CheckValid<T1, T2, T3, T4>(Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<bool>> function)
         {
-            foreach (var p in parameters)
+            // If testing on strings, only use Z3 backend (DD does not support strings)
+            TestParameter[] selectedParams = parameters;
+            if (typeof(T1) == ReflectionUtilities.StringType
+             || typeof(T2) == ReflectionUtilities.StringType
+             || typeof(T3) == ReflectionUtilities.StringType
+             || typeof(T4) == ReflectionUtilities.StringType)
+            {
+                selectedParams = stringParameters;
+            }
+            foreach (var p in selectedParams)
             {
                 Start(p);
 
@@ -186,7 +225,12 @@ namespace ZenLib.Tests
         /// <param name="function">The predicate.</param>
         public static void CheckNotValid<T1>(Func<Zen<T1>, Zen<bool>> function)
         {
-            foreach (var p in parameters)
+            TestParameter[] selectedParams = parameters;
+            if (typeof(T1) == ReflectionUtilities.StringType)
+            {
+                selectedParams = stringParameters;
+            }
+            foreach (var p in selectedParams)
             {
                 Start(p);
 
@@ -212,7 +256,13 @@ namespace ZenLib.Tests
         /// <param name="function">The predicate.</param>
         public static void CheckNotValid<T1, T2>(Func<Zen<T1>, Zen<T2>, Zen<bool>> function)
         {
-            foreach (var p in parameters)
+            TestParameter[] selectedParams = parameters;
+            if (typeof(T1) == ReflectionUtilities.StringType
+             || typeof(T2) == ReflectionUtilities.StringType)
+            {
+                selectedParams = stringParameters;
+            }
+            foreach (var p in selectedParams)
             {
                 Start(p);
 
@@ -256,7 +306,12 @@ namespace ZenLib.Tests
         /// <param name="function">The function.</param>
         public static void CheckAgreement<T1>(Func<Zen<T1>, Zen<bool>> function)
         {
-            foreach (var p in parameters)
+            TestParameter[] selectedParams = parameters;
+            if (typeof(T1) == ReflectionUtilities.StringType)
+            {
+                selectedParams = stringParameters;
+            }
+            foreach (var p in selectedParams)
             {
                 Start(p);
 
@@ -282,7 +337,13 @@ namespace ZenLib.Tests
         /// <param name="function">The function.</param>
         public static void CheckAgreement<T1, T2>(Func<Zen<T1>, Zen<T2>, Zen<bool>> function)
         {
-            foreach (var p in parameters)
+            TestParameter[] selectedParams = parameters;
+            if (typeof(T1) == ReflectionUtilities.StringType
+             || typeof(T2) == ReflectionUtilities.StringType)
+            {
+                selectedParams = stringParameters;
+            }
+            foreach (var p in selectedParams)
             {
                 Start(p);
 


### PR DESCRIPTION
This PR adds string support through Zen's Z3 backend, so that Zen users can compile, evaluate, and check code manipulating strings.

Supported features are:
-string variables
-string constants
-equality comparisons between strings
-string concatenation