### PR TITLE
Reuse function bodies in ZenFunction

### DIFF
--- a/ZenLib/CommonUtilities.cs
+++ b/ZenLib/CommonUtilities.cs
@@ -12,6 +12,7 @@ namespace ZenLib
     using System.Numerics;
     using System.Text;
     using System.Threading;
+    using ExceptionDispatchInfo = System.Runtime.ExceptionServices.ExceptionDispatchInfo;
 
     /// <summary>
     /// A collection of common utility functions.
@@ -409,6 +410,25 @@ namespace ZenLib
             }
 
             return s[(int)index].ToString();
+        }
+
+        /// <summary>
+        ///     Tries to run a callback and, if the callback
+        ///     triggers a target invocation exception, then
+        ///     it rethrows with the original exception.
+        /// </summary>
+        /// <param name="action">The callback.</param>
+        /// <returns>The value from the callback.</returns>
+        public static T RunAndPreserveExceptions<T>(Func<T> action)
+        {
+            try
+            {
+                return action();
+            }
+            catch (System.Reflection.TargetInvocationException e)
+            {
+                throw e.InnerException;
+            }
         }
     }
 }

--- a/ZenLib/Compilation/CodeGenerator.cs
+++ b/ZenLib/Compilation/CodeGenerator.cs
@@ -17,15 +17,17 @@ namespace ZenLib.Compilation
         /// <summary>
         /// Compile a Zen expression to native IL.
         /// </summary>
-        /// <param name="function">The function.</param>
+        /// <param name="expression">The function expression.</param>
+        /// <param name="arguments">The arguments.</param>
         /// <param name="maxUnrollingDepth">The maximum unrolling depth.</param>
         /// <returns>A native IL function.</returns>
-        public static Func<T> Compile<T>(Func<Zen<T>> function, int maxUnrollingDepth)
+        public static Func<T> Compile<T>(
+            Zen<T> expression,
+            ImmutableDictionary<long, Expression> arguments,
+            int maxUnrollingDepth)
         {
-            var args = ImmutableDictionary<long, Expression>.Empty;
-            var env = new ExpressionConverterEnvironment(args);
-            var e = function();
-            var expr = CompileToBlock(e, env, ImmutableDictionary<object, Expression>.Empty, 0, maxUnrollingDepth);
+            var env = new ExpressionConverterEnvironment(arguments);
+            var expr = CompileToBlock(expression, env, ImmutableDictionary<object, Expression>.Empty, 0, maxUnrollingDepth);
             var lambda = Expression.Lambda<Func<T>>(expr, new ParameterExpression[] { });
             return lambda.Compile();
         }
@@ -33,20 +35,19 @@ namespace ZenLib.Compilation
         /// <summary>
         /// Compile a Zen expression to native IL.
         /// </summary>
-        /// <param name="function">The function.</param>
+        /// <param name="expression">The function expression.</param>
+        /// <param name="arguments">The arguments.</param>
+        /// <param name="param1">The first parameter.</param>
         /// <param name="maxUnrollingDepth">The maximum unrolling depth.</param>
         /// <returns>A native IL function.</returns>
-        public static Func<T1, T2> Compile<T1, T2>(Func<Zen<T1>, Zen<T2>> function, int maxUnrollingDepth)
+        public static Func<T1, T2> Compile<T1, T2>(
+            Zen<T2> expression,
+            ImmutableDictionary<long, Expression> arguments,
+            ParameterExpression param1,
+            int maxUnrollingDepth)
         {
-            var args = ImmutableDictionary<long, Expression>.Empty;
-
-            var arg1 = new ZenArgumentExpr<T1>();
-            var param1 = Expression.Parameter(typeof(T1));
-            args = args.Add(arg1.ArgumentId, param1);
-
-            var env = new ExpressionConverterEnvironment(args);
-            var e = function(arg1);
-            var expr = CompileToBlock(e, env, ImmutableDictionary<object, Expression>.Empty, 0, maxUnrollingDepth);
+            var env = new ExpressionConverterEnvironment(arguments);
+            var expr = CompileToBlock(expression, env, ImmutableDictionary<object, Expression>.Empty, 0, maxUnrollingDepth);
             var lambda = Expression.Lambda<Func<T1, T2>>(expr, new ParameterExpression[] { param1 });
             return lambda.Compile();
         }
@@ -54,24 +55,21 @@ namespace ZenLib.Compilation
         /// <summary>
         /// Compile a Zen expression to native IL.
         /// </summary>
-        /// <param name="function">The function.</param>
+        /// <param name="expression">The function expression.</param>
+        /// <param name="arguments">The function arguments.</param>
+        /// <param name="param1">The first parameter.</param>
+        /// <param name="param2">The second parameter.</param>
         /// <param name="maxUnrollingDepth">The maximum unrolling depth.</param>
         /// <returns>A native IL function.</returns>
-        public static Func<T1, T2, T3> Compile<T1, T2, T3>(Func<Zen<T1>, Zen<T2>, Zen<T3>> function, int maxUnrollingDepth)
+        public static Func<T1, T2, T3> Compile<T1, T2, T3>(
+            Zen<T3> expression,
+            ImmutableDictionary<long, Expression> arguments,
+            ParameterExpression param1,
+            ParameterExpression param2,
+            int maxUnrollingDepth)
         {
-            var args = ImmutableDictionary<long, Expression>.Empty;
-
-            var arg1 = new ZenArgumentExpr<T1>();
-            var param1 = Expression.Parameter(typeof(T1));
-            args = args.Add(arg1.ArgumentId, param1);
-
-            var arg2 = new ZenArgumentExpr<T2>();
-            var param2 = Expression.Parameter(typeof(T2));
-            args = args.Add(arg2.ArgumentId, param2);
-
-            var env = new ExpressionConverterEnvironment(args);
-            var e = function(arg1, arg2);
-            var expr = CompileToBlock(e, env, ImmutableDictionary<object, Expression>.Empty, 0, maxUnrollingDepth);
+            var env = new ExpressionConverterEnvironment(arguments);
+            var expr = CompileToBlock(expression, env, ImmutableDictionary<object, Expression>.Empty, 0, maxUnrollingDepth);
             var lambda = Expression.Lambda<Func<T1, T2, T3>>(expr, new ParameterExpression[] { param1, param2 });
             return lambda.Compile();
         }
@@ -79,28 +77,23 @@ namespace ZenLib.Compilation
         /// <summary>
         /// Compile a Zen expression to native IL.
         /// </summary>
-        /// <param name="function">The function.</param>
+        /// <param name="expression">The function expression.</param>
+        /// <param name="arguments">The function arguments.</param>
+        /// <param name="param1">The first parameter.</param>
+        /// <param name="param2">The second parameter.</param>
+        /// <param name="param3">The third parameter.</param>
         /// <param name="maxUnrollingDepth">The maximum unrolling depth.</param>
         /// <returns>A native IL function.</returns>
-        public static Func<T1, T2, T3, T4> Compile<T1, T2, T3, T4>(Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>> function, int maxUnrollingDepth)
+        public static Func<T1, T2, T3, T4> Compile<T1, T2, T3, T4>(
+            Zen<T4> expression,
+            ImmutableDictionary<long, Expression> arguments,
+            ParameterExpression param1,
+            ParameterExpression param2,
+            ParameterExpression param3,
+            int maxUnrollingDepth)
         {
-            var args = ImmutableDictionary<long, Expression>.Empty;
-
-            var arg1 = new ZenArgumentExpr<T1>();
-            var param1 = Expression.Parameter(typeof(T1));
-            args = args.Add(arg1.ArgumentId, param1);
-
-            var arg2 = new ZenArgumentExpr<T2>();
-            var param2 = Expression.Parameter(typeof(T2));
-            args = args.Add(arg2.ArgumentId, param2);
-
-            var arg3 = new ZenArgumentExpr<T3>();
-            var param3 = Expression.Parameter(typeof(T3));
-            args = args.Add(arg3.ArgumentId, param3);
-
-            var env = new ExpressionConverterEnvironment(args);
-            var e = function(arg1, arg2, arg3);
-            var expr = CompileToBlock(e, env, ImmutableDictionary<object, Expression>.Empty, 0, maxUnrollingDepth);
+            var env = new ExpressionConverterEnvironment(arguments);
+            var expr = CompileToBlock(expression, env, ImmutableDictionary<object, Expression>.Empty, 0, maxUnrollingDepth);
             var lambda = Expression.Lambda<Func<T1, T2, T3, T4>>(expr, new ParameterExpression[] { param1, param2, param3 });
             return lambda.Compile();
         }
@@ -108,32 +101,25 @@ namespace ZenLib.Compilation
         /// <summary>
         /// Compile a Zen expression to native IL.
         /// </summary>
-        /// <param name="function">The function.</param>
+        /// <param name="expression">The function.</param>
+        /// <param name="arguments">The function arguments.</param>
+        /// <param name="param1">The first parameter.</param>
+        /// <param name="param2">The second parameter.</param>
+        /// <param name="param3">The third parameter.</param>
+        /// <param name="param4">The fourth parameter.</param>
         /// <param name="maxUnrollingDepth">The maximum unrolling depth.</param>
         /// <returns>A native IL function.</returns>
-        public static Func<T1, T2, T3, T4, T5> Compile<T1, T2, T3, T4, T5>(Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<T5>> function, int maxUnrollingDepth)
+        public static Func<T1, T2, T3, T4, T5> Compile<T1, T2, T3, T4, T5>(
+            Zen<T5> expression,
+            ImmutableDictionary<long, Expression> arguments,
+            ParameterExpression param1,
+            ParameterExpression param2,
+            ParameterExpression param3,
+            ParameterExpression param4,
+            int maxUnrollingDepth)
         {
-            var args = ImmutableDictionary<long, Expression>.Empty;
-
-            var arg1 = new ZenArgumentExpr<T1>();
-            var param1 = Expression.Parameter(typeof(T1));
-            args = args.Add(arg1.ArgumentId, param1);
-
-            var arg2 = new ZenArgumentExpr<T2>();
-            var param2 = Expression.Parameter(typeof(T2));
-            args = args.Add(arg2.ArgumentId, param2);
-
-            var arg3 = new ZenArgumentExpr<T3>();
-            var param3 = Expression.Parameter(typeof(T3));
-            args = args.Add(arg3.ArgumentId, param3);
-
-            var arg4 = new ZenArgumentExpr<T4>();
-            var param4 = Expression.Parameter(typeof(T4));
-            args = args.Add(arg4.ArgumentId, param4);
-
-            var env = new ExpressionConverterEnvironment(args);
-            var e = function(arg1, arg2, arg3, arg4);
-            var expr = CompileToBlock(e, env, ImmutableDictionary<object, Expression>.Empty, 0, maxUnrollingDepth);
+            var env = new ExpressionConverterEnvironment(arguments);
+            var expr = CompileToBlock(expression, env, ImmutableDictionary<object, Expression>.Empty, 0, maxUnrollingDepth);
             var lambda = Expression.Lambda<Func<T1, T2, T3, T4, T5>>(expr, new ParameterExpression[] { param1, param2, param3, param4 });
             return lambda.Compile();
         }

--- a/ZenLib/Interpretation/ExpressionEvaluator.cs
+++ b/ZenLib/Interpretation/ExpressionEvaluator.cs
@@ -67,27 +67,24 @@ namespace ZenLib.Interpretation
 
         public object VisitZenArbitraryExpr<T>(ZenArbitraryExpr<T> expression, ExpressionEvaluatorEnvironment parameter)
         {
-            return LookupOrCompute(expression, parameter, () =>
-            {
-                if (parameter.ArbitraryAssignment == null)
-                    return ReflectionUtilities.GetDefaultValue<T>();
-                if (!parameter.ArbitraryAssignment.TryGetValue(expression, out var value))
-                    return ReflectionUtilities.GetDefaultValue<T>();
+            if (parameter.ArbitraryAssignment == null)
+                return ReflectionUtilities.GetDefaultValue<T>();
+            if (!parameter.ArbitraryAssignment.TryGetValue(expression, out var value))
+                return ReflectionUtilities.GetDefaultValue<T>();
 
-                // the library doesn't distinguish between signed and unsigned,
-                // so we must perform this conversion manually.
-                var type = typeof(T);
-                if (type != value.GetType())
-                {
-                    if (type == ReflectionUtilities.UshortType)
-                        return (ushort)(short)value;
-                    if (type == ReflectionUtilities.UintType)
-                        return (uint)(int)value;
-                    if (type == ReflectionUtilities.UlongType)
-                        return (ulong)(long)value;
-                }
-                return value;
-            });
+            // the library doesn't distinguish between signed and unsigned,
+            // so we must perform this conversion manually.
+            var type = typeof(T);
+            if (type != value.GetType())
+            {
+                if (type == ReflectionUtilities.UshortType)
+                    return (ushort)(short)value;
+                if (type == ReflectionUtilities.UintType)
+                    return (uint)(int)value;
+                if (type == ReflectionUtilities.UlongType)
+                    return (ulong)(long)value;
+            }
+            return value;
         }
 
         public object VisitZenAndExpr(ZenAndExpr expression, ExpressionEvaluatorEnvironment parameter)

--- a/ZenLib/Interpretation/Interpreter.cs
+++ b/ZenLib/Interpretation/Interpreter.cs
@@ -14,69 +14,15 @@ namespace ZenLib.Interpretation
     /// </summary>
     internal static class Interpreter
     {
-        public static (T, PathConstraint) Run<T>(Func<Zen<T>> function, bool trackBranches = false)
+        /// <summary>
+        /// Execute an expression with some arguments.
+        /// </summary>
+        /// <param name="expression">The function as an expression.</param>
+        /// <param name="args">The arguments with values as C# values.</param>
+        /// <param name="trackBranches">Whether to track branches.</param>
+        /// <returns>The result and any path constraint.</returns>
+        public static (T, PathConstraint) Run<T>(Zen<T> expression, ImmutableDictionary<long, object> args, bool trackBranches = false)
         {
-            var args = ImmutableDictionary<long, object>.Empty;
-            var expression = function();
-            return Interpret(expression, args, trackBranches);
-        }
-
-        public static (T2, PathConstraint) Run<T1, T2>(Func<Zen<T1>, Zen<T2>> function, T1 value1, bool trackBranches = false)
-        {
-            var arg1 = new ZenArgumentExpr<T1>();
-            var args = ImmutableDictionary<long, object>.Empty;
-            args = args.Add(arg1.ArgumentId, value1);
-            var expression = function(arg1);
-            return Interpret(expression, args, trackBranches);
-        }
-
-        public static (T3, PathConstraint) Run<T1, T2, T3>(Func<Zen<T1>, Zen<T2>, Zen<T3>> function, T1 value1, T2 value2, bool trackBranches = false)
-        {
-            var arg1 = new ZenArgumentExpr<T1>();
-            var arg2 = new ZenArgumentExpr<T2>();
-            var args = ImmutableDictionary<long, object>.Empty;
-            args = args.Add(arg1.ArgumentId, value1);
-            args = args.Add(arg2.ArgumentId, value2);
-            var expression = function(arg1, arg2);
-            return Interpret(expression, args, trackBranches);
-        }
-
-        public static (T4, PathConstraint) Run<T1, T2, T3, T4>(
-            Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>> function,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            bool trackBranches = false)
-        {
-            var arg1 = new ZenArgumentExpr<T1>();
-            var arg2 = new ZenArgumentExpr<T2>();
-            var arg3 = new ZenArgumentExpr<T3>();
-            var args = ImmutableDictionary<long, object>.Empty;
-            args = args.Add(arg1.ArgumentId, value1);
-            args = args.Add(arg2.ArgumentId, value2);
-            args = args.Add(arg3.ArgumentId, value3);
-            var expression = function(arg1, arg2, arg3);
-            return Interpret(expression, args, trackBranches);
-        }
-
-        public static (T5, PathConstraint) Run<T1, T2, T3, T4, T5>(
-            Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<T5>> function,
-            T1 value1,
-            T2 value2,
-            T3 value3,
-            T4 value4,
-            bool trackBranches = false)
-        {
-            var arg1 = new ZenArgumentExpr<T1>();
-            var arg2 = new ZenArgumentExpr<T2>();
-            var arg3 = new ZenArgumentExpr<T3>();
-            var arg4 = new ZenArgumentExpr<T4>();
-            var args = ImmutableDictionary<long, object>.Empty;
-            args = args.Add(arg1.ArgumentId, value1);
-            args = args.Add(arg2.ArgumentId, value2);
-            args = args.Add(arg3.ArgumentId, value3);
-            args = args.Add(arg4.ArgumentId, value4);
-            var expression = function(arg1, arg2, arg3, arg4);
             return Interpret(expression, args, trackBranches);
         }
 
@@ -85,7 +31,6 @@ namespace ZenLib.Interpretation
             var environment = new ExpressionEvaluatorEnvironment(arguments);
             var interpreter = new ExpressionEvaluator(trackBranches);
             var result = (T)expression.Accept(interpreter, environment);
-
             return (result, interpreter.PathConstraint);
         }
 

--- a/ZenLib/ModelChecking/IModelChecker.cs
+++ b/ZenLib/ModelChecking/IModelChecker.cs
@@ -5,7 +5,6 @@
 namespace ZenLib.ModelChecking
 {
     using System.Collections.Generic;
-    using System.Collections.Immutable;
 
     /// <summary>
     /// Interface for a model checker.
@@ -21,6 +20,6 @@ namespace ZenLib.ModelChecking
         ///     Mapping from zen arbitrary expression to value.
         ///     Null if there is no input.
         /// </returns>
-        Dictionary<object, object> ModelCheck(Zen<bool> expression, ImmutableDictionary<long, object> arguments);
+        Dictionary<object, object> ModelCheck(Zen<bool> expression, Dictionary<long, object> arguments);
     }
 }

--- a/ZenLib/ModelChecking/IModelChecker.cs
+++ b/ZenLib/ModelChecking/IModelChecker.cs
@@ -5,6 +5,7 @@
 namespace ZenLib.ModelChecking
 {
     using System.Collections.Generic;
+    using System.Collections.Immutable;
 
     /// <summary>
     /// Interface for a model checker.
@@ -15,10 +16,11 @@ namespace ZenLib.ModelChecking
         /// Find an input satisfying the expression via model checking.
         /// </summary>
         /// <param name="expression">The boolean expression.</param>
+        /// <param name="arguments">The arguments.</param>
         /// <returns>
         ///     Mapping from zen arbitrary expression to value.
         ///     Null if there is no input.
         /// </returns>
-        Dictionary<object, object> ModelCheck(Zen<bool> expression);
+        Dictionary<object, object> ModelCheck(Zen<bool> expression, ImmutableDictionary<long, object> arguments);
     }
 }

--- a/ZenLib/ModelChecking/InterleavingHeuristic.cs
+++ b/ZenLib/ModelChecking/InterleavingHeuristic.cs
@@ -15,7 +15,7 @@ namespace ZenLib.ModelChecking
     /// Class to conservatively estimate which variables
     /// must be interleaved to avoid exponential blowup in the encoding.
     /// </summary>
-    internal sealed class InterleavingHeuristic : IZenExprVisitor<Unit, ImmutableHashSet<object>>
+    internal sealed class InterleavingHeuristic : IZenExprVisitor<ImmutableDictionary<long, object>, ImmutableHashSet<object>>
     {
         private static Type ZenBoolType = typeof(Zen<bool>);
 
@@ -45,9 +45,9 @@ namespace ZenLib.ModelChecking
             return result;
         }
 
-        public Dictionary<object, ImmutableHashSet<object>> Compute<T>(Zen<T> expr)
+        public Dictionary<object, ImmutableHashSet<object>> Compute<T>(Zen<T> expr, ImmutableDictionary<long, object> arguments)
         {
-            var _ = expr.Accept(this, new Unit());
+            var _ = expr.Accept(this, arguments);
             return this.DisjointSets;
         }
 
@@ -85,7 +85,7 @@ namespace ZenLib.ModelChecking
             }
         }
 
-        public ImmutableHashSet<object> VisitZenAndExpr(ZenAndExpr expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenAndExpr(ZenAndExpr expression, ImmutableDictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -95,7 +95,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenOrExpr(ZenOrExpr expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenOrExpr(ZenOrExpr expression, ImmutableDictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -105,7 +105,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenNotExpr(ZenNotExpr expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenNotExpr(ZenNotExpr expression, ImmutableDictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -113,7 +113,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenIfExpr<T>(ZenIfExpr<T> expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenIfExpr<T>(ZenIfExpr<T> expression, ImmutableDictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -124,12 +124,12 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenConstantExpr<T>(ZenConstantExpr<T> expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenConstantExpr<T>(ZenConstantExpr<T> expression, ImmutableDictionary<long, object> parameter)
         {
             return emptySet;
         }
 
-        public ImmutableHashSet<object> VisitZenIntegerBinopExpr<T>(ZenIntegerBinopExpr<T> expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenIntegerBinopExpr<T>(ZenIntegerBinopExpr<T> expression, ImmutableDictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -151,7 +151,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenConcatExpr(ZenConcatExpr expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenConcatExpr(ZenConcatExpr expression, ImmutableDictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -163,42 +163,42 @@ namespace ZenLib.ModelChecking
         }
 
         [ExcludeFromCodeCoverage]
-        public ImmutableHashSet<object> VisitZenStringContainmentExpr(ZenStringContainmentExpr expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenStringContainmentExpr(ZenStringContainmentExpr expression, ImmutableDictionary<long, object> parameter)
         {
             throw new ZenException($"Invalid string type used with Decision Diagram backend.");
         }
 
         [ExcludeFromCodeCoverage]
-        public ImmutableHashSet<object> VisitZenStringReplaceExpr(ZenStringReplaceExpr expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenStringReplaceExpr(ZenStringReplaceExpr expression, ImmutableDictionary<long, object> parameter)
         {
             throw new ZenException($"Invalid string type used with Decision Diagram backend.");
         }
 
         [ExcludeFromCodeCoverage]
-        public ImmutableHashSet<object> VisitZenStringSubstringExpr(ZenStringSubstringExpr expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenStringSubstringExpr(ZenStringSubstringExpr expression, ImmutableDictionary<long, object> parameter)
         {
             throw new ZenException($"Invalid string type used with Decision Diagram backend.");
         }
 
         [ExcludeFromCodeCoverage]
-        public ImmutableHashSet<object> VisitZenStringAtExpr(ZenStringAtExpr expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenStringAtExpr(ZenStringAtExpr expression, ImmutableDictionary<long, object> parameter)
         {
             throw new ZenException($"Invalid string type used with Decision Diagram backend.");
         }
 
         [ExcludeFromCodeCoverage]
-        public ImmutableHashSet<object> VisitZenStringLengthExpr(ZenStringLengthExpr expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenStringLengthExpr(ZenStringLengthExpr expression, ImmutableDictionary<long, object> parameter)
         {
             throw new ZenException($"Invalid string type used with Decision Diagram backend.");
         }
 
         [ExcludeFromCodeCoverage]
-        public ImmutableHashSet<object> VisitZenStringIndexOfExpr(ZenStringIndexOfExpr expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenStringIndexOfExpr(ZenStringIndexOfExpr expression, ImmutableDictionary<long, object> parameter)
         {
             throw new ZenException($"Invalid string type used with Decision Diagram backend.");
         }
 
-        public ImmutableHashSet<object> VisitZenBitwiseNotExpr<T>(ZenBitwiseNotExpr<T> expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenBitwiseNotExpr<T>(ZenBitwiseNotExpr<T> expression, ImmutableDictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -206,12 +206,12 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenListEmptyExpr<T>(ZenListEmptyExpr<T> expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenListEmptyExpr<T>(ZenListEmptyExpr<T> expression, ImmutableDictionary<long, object> parameter)
         {
             return emptySet;
         }
 
-        public ImmutableHashSet<object> VisitZenListAddFrontExpr<T>(ZenListAddFrontExpr<T> expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenListAddFrontExpr<T>(ZenListAddFrontExpr<T> expression, ImmutableDictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -221,7 +221,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenListCaseExpr<TList, TResult>(ZenListCaseExpr<TList, TResult> expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenListCaseExpr<TList, TResult>(ZenListCaseExpr<TList, TResult> expression, ImmutableDictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -231,7 +231,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenGetFieldExpr<T1, T2>(ZenGetFieldExpr<T1, T2> expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenGetFieldExpr<T1, T2>(ZenGetFieldExpr<T1, T2> expression, ImmutableDictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -239,7 +239,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenWithFieldExpr<T1, T2>(ZenWithFieldExpr<T1, T2> expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenWithFieldExpr<T1, T2>(ZenWithFieldExpr<T1, T2> expression, ImmutableDictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -249,18 +249,21 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenCreateObjectExpr<TObject>(ZenCreateObjectExpr<TObject> expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenCreateObjectExpr<TObject>(ZenCreateObjectExpr<TObject> expression, ImmutableDictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
                 var set = ImmutableHashSet<object>.Empty;
                 foreach (var value in expression.Fields.Values)
                 {
-                    var valueType = value.GetType();
-                    var acceptMethod = valueType
-                        .GetMethod("Accept", BindingFlags.NonPublic | BindingFlags.Instance)
-                        .MakeGenericMethod(typeof(Unit), typeof(ImmutableHashSet<object>));
-                    var valueResult = (ImmutableHashSet<object>)acceptMethod.Invoke(value, new object[] { this, parameter });
+                    var valueResult = CommonUtilities.RunAndPreserveExceptions(() =>
+                    {
+                        var valueType = value.GetType();
+                        var acceptMethod = valueType
+                            .GetMethod("Accept", BindingFlags.NonPublic | BindingFlags.Instance)
+                            .MakeGenericMethod(typeof(ImmutableDictionary<long, object>), typeof(ImmutableHashSet<object>));
+                        return (ImmutableHashSet<object>)acceptMethod.Invoke(value, new object[] { this, parameter });
+                    });
 
                     set = set.Union(valueResult);
                 }
@@ -269,7 +272,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenComparisonExpr<T>(ZenComparisonExpr<T> expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenComparisonExpr<T>(ZenComparisonExpr<T> expression, ImmutableDictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -281,12 +284,22 @@ namespace ZenLib.ModelChecking
         }
 
         [ExcludeFromCodeCoverage]
-        public ImmutableHashSet<object> VisitZenArgumentExpr<T>(ZenArgumentExpr<T> expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenArgumentExpr<T>(ZenArgumentExpr<T> expression, ImmutableDictionary<long, object> parameter)
         {
-            throw new UnreachableException();
+            return LookupOrCompute(expression, () =>
+            {
+                return CommonUtilities.RunAndPreserveExceptions(() =>
+                {
+                    var expr = parameter[expression.ArgumentId];
+                    var acceptMethod = expr.GetType()
+                        .GetMethod("Accept", BindingFlags.NonPublic | BindingFlags.Instance)
+                        .MakeGenericMethod(typeof(ImmutableDictionary<long, object>), typeof(ImmutableHashSet<object>));
+                    return (ImmutableHashSet<object>)acceptMethod.Invoke(expr, new object[] { this, parameter });
+                });
+            });
         }
 
-        public ImmutableHashSet<object> VisitZenArbitraryExpr<T>(ZenArbitraryExpr<T> expression, Unit parameter)
+        public ImmutableHashSet<object> VisitZenArbitraryExpr<T>(ZenArbitraryExpr<T> expression, ImmutableDictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {

--- a/ZenLib/ModelChecking/InterleavingHeuristic.cs
+++ b/ZenLib/ModelChecking/InterleavingHeuristic.cs
@@ -15,7 +15,7 @@ namespace ZenLib.ModelChecking
     /// Class to conservatively estimate which variables
     /// must be interleaved to avoid exponential blowup in the encoding.
     /// </summary>
-    internal sealed class InterleavingHeuristic : IZenExprVisitor<ImmutableDictionary<long, object>, ImmutableHashSet<object>>
+    internal sealed class InterleavingHeuristic : IZenExprVisitor<Dictionary<long, object>, ImmutableHashSet<object>>
     {
         private static Type ZenBoolType = typeof(Zen<bool>);
 
@@ -45,7 +45,7 @@ namespace ZenLib.ModelChecking
             return result;
         }
 
-        public Dictionary<object, ImmutableHashSet<object>> Compute<T>(Zen<T> expr, ImmutableDictionary<long, object> arguments)
+        public Dictionary<object, ImmutableHashSet<object>> Compute<T>(Zen<T> expr, Dictionary<long, object> arguments)
         {
             var _ = expr.Accept(this, arguments);
             return this.DisjointSets;
@@ -85,7 +85,7 @@ namespace ZenLib.ModelChecking
             }
         }
 
-        public ImmutableHashSet<object> VisitZenAndExpr(ZenAndExpr expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenAndExpr(ZenAndExpr expression, Dictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -95,7 +95,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenOrExpr(ZenOrExpr expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenOrExpr(ZenOrExpr expression, Dictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -105,7 +105,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenNotExpr(ZenNotExpr expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenNotExpr(ZenNotExpr expression, Dictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -113,7 +113,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenIfExpr<T>(ZenIfExpr<T> expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenIfExpr<T>(ZenIfExpr<T> expression, Dictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -124,12 +124,12 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenConstantExpr<T>(ZenConstantExpr<T> expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenConstantExpr<T>(ZenConstantExpr<T> expression, Dictionary<long, object> parameter)
         {
             return emptySet;
         }
 
-        public ImmutableHashSet<object> VisitZenIntegerBinopExpr<T>(ZenIntegerBinopExpr<T> expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenIntegerBinopExpr<T>(ZenIntegerBinopExpr<T> expression, Dictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -151,7 +151,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenConcatExpr(ZenConcatExpr expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenConcatExpr(ZenConcatExpr expression, Dictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -163,42 +163,42 @@ namespace ZenLib.ModelChecking
         }
 
         [ExcludeFromCodeCoverage]
-        public ImmutableHashSet<object> VisitZenStringContainmentExpr(ZenStringContainmentExpr expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenStringContainmentExpr(ZenStringContainmentExpr expression, Dictionary<long, object> parameter)
         {
             throw new ZenException($"Invalid string type used with Decision Diagram backend.");
         }
 
         [ExcludeFromCodeCoverage]
-        public ImmutableHashSet<object> VisitZenStringReplaceExpr(ZenStringReplaceExpr expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenStringReplaceExpr(ZenStringReplaceExpr expression, Dictionary<long, object> parameter)
         {
             throw new ZenException($"Invalid string type used with Decision Diagram backend.");
         }
 
         [ExcludeFromCodeCoverage]
-        public ImmutableHashSet<object> VisitZenStringSubstringExpr(ZenStringSubstringExpr expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenStringSubstringExpr(ZenStringSubstringExpr expression, Dictionary<long, object> parameter)
         {
             throw new ZenException($"Invalid string type used with Decision Diagram backend.");
         }
 
         [ExcludeFromCodeCoverage]
-        public ImmutableHashSet<object> VisitZenStringAtExpr(ZenStringAtExpr expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenStringAtExpr(ZenStringAtExpr expression, Dictionary<long, object> parameter)
         {
             throw new ZenException($"Invalid string type used with Decision Diagram backend.");
         }
 
         [ExcludeFromCodeCoverage]
-        public ImmutableHashSet<object> VisitZenStringLengthExpr(ZenStringLengthExpr expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenStringLengthExpr(ZenStringLengthExpr expression, Dictionary<long, object> parameter)
         {
             throw new ZenException($"Invalid string type used with Decision Diagram backend.");
         }
 
         [ExcludeFromCodeCoverage]
-        public ImmutableHashSet<object> VisitZenStringIndexOfExpr(ZenStringIndexOfExpr expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenStringIndexOfExpr(ZenStringIndexOfExpr expression, Dictionary<long, object> parameter)
         {
             throw new ZenException($"Invalid string type used with Decision Diagram backend.");
         }
 
-        public ImmutableHashSet<object> VisitZenBitwiseNotExpr<T>(ZenBitwiseNotExpr<T> expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenBitwiseNotExpr<T>(ZenBitwiseNotExpr<T> expression, Dictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -206,12 +206,12 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenListEmptyExpr<T>(ZenListEmptyExpr<T> expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenListEmptyExpr<T>(ZenListEmptyExpr<T> expression, Dictionary<long, object> parameter)
         {
             return emptySet;
         }
 
-        public ImmutableHashSet<object> VisitZenListAddFrontExpr<T>(ZenListAddFrontExpr<T> expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenListAddFrontExpr<T>(ZenListAddFrontExpr<T> expression, Dictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -221,7 +221,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenListCaseExpr<TList, TResult>(ZenListCaseExpr<TList, TResult> expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenListCaseExpr<TList, TResult>(ZenListCaseExpr<TList, TResult> expression, Dictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -231,7 +231,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenGetFieldExpr<T1, T2>(ZenGetFieldExpr<T1, T2> expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenGetFieldExpr<T1, T2>(ZenGetFieldExpr<T1, T2> expression, Dictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -239,7 +239,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenWithFieldExpr<T1, T2>(ZenWithFieldExpr<T1, T2> expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenWithFieldExpr<T1, T2>(ZenWithFieldExpr<T1, T2> expression, Dictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -249,7 +249,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenCreateObjectExpr<TObject>(ZenCreateObjectExpr<TObject> expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenCreateObjectExpr<TObject>(ZenCreateObjectExpr<TObject> expression, Dictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -261,7 +261,7 @@ namespace ZenLib.ModelChecking
                         var valueType = value.GetType();
                         var acceptMethod = valueType
                             .GetMethod("Accept", BindingFlags.NonPublic | BindingFlags.Instance)
-                            .MakeGenericMethod(typeof(ImmutableDictionary<long, object>), typeof(ImmutableHashSet<object>));
+                            .MakeGenericMethod(typeof(Dictionary<long, object>), typeof(ImmutableHashSet<object>));
                         return (ImmutableHashSet<object>)acceptMethod.Invoke(value, new object[] { this, parameter });
                     });
 
@@ -272,7 +272,7 @@ namespace ZenLib.ModelChecking
             });
         }
 
-        public ImmutableHashSet<object> VisitZenComparisonExpr<T>(ZenComparisonExpr<T> expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenComparisonExpr<T>(ZenComparisonExpr<T> expression, Dictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -284,7 +284,7 @@ namespace ZenLib.ModelChecking
         }
 
         [ExcludeFromCodeCoverage]
-        public ImmutableHashSet<object> VisitZenArgumentExpr<T>(ZenArgumentExpr<T> expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenArgumentExpr<T>(ZenArgumentExpr<T> expression, Dictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {
@@ -293,13 +293,13 @@ namespace ZenLib.ModelChecking
                     var expr = parameter[expression.ArgumentId];
                     var acceptMethod = expr.GetType()
                         .GetMethod("Accept", BindingFlags.NonPublic | BindingFlags.Instance)
-                        .MakeGenericMethod(typeof(ImmutableDictionary<long, object>), typeof(ImmutableHashSet<object>));
+                        .MakeGenericMethod(typeof(Dictionary<long, object>), typeof(ImmutableHashSet<object>));
                     return (ImmutableHashSet<object>)acceptMethod.Invoke(expr, new object[] { this, parameter });
                 });
             });
         }
 
-        public ImmutableHashSet<object> VisitZenArbitraryExpr<T>(ZenArbitraryExpr<T> expression, ImmutableDictionary<long, object> parameter)
+        public ImmutableHashSet<object> VisitZenArbitraryExpr<T>(ZenArbitraryExpr<T> expression, Dictionary<long, object> parameter)
         {
             return LookupOrCompute(expression, () =>
             {

--- a/ZenLib/ModelChecking/ModelChecker.cs
+++ b/ZenLib/ModelChecking/ModelChecker.cs
@@ -6,6 +6,7 @@ namespace ZenLib.ModelChecking
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using ZenLib.Solver;
 
     /// <summary>
@@ -35,14 +36,15 @@ namespace ZenLib.ModelChecking
         /// Model check an expression to find inputs that lead to it being false.
         /// </summary>
         /// <param name="expression">The expression.</param>
+        /// <param name="arguments">The arguments.</param>
         /// <returns>
         ///     Assignment to zen arbitrary variables that make the expression false.
         ///     Null if no such assignment exists.
         /// </returns>
-        public Dictionary<object, object> ModelCheck(Zen<bool> expression)
+        public Dictionary<object, object> ModelCheck(Zen<bool> expression, ImmutableDictionary<long, object> arguments)
         {
             var symbolicEvaluator = new SymbolicEvaluationVisitor<TModel, TVar, TBool, TBitvec, TInt, TString>(solver);
-            var env = new SymbolicEvaluationEnvironment<TModel, TVar, TBool, TBitvec, TInt, TString>();
+            var env = new SymbolicEvaluationEnvironment<TModel, TVar, TBool, TBitvec, TInt, TString>(arguments);
             var symbolicResult =
                 (SymbolicBool<TModel, TVar, TBool, TBitvec, TInt, TString>)expression.Accept(symbolicEvaluator, env);
 

--- a/ZenLib/ModelChecking/ModelChecker.cs
+++ b/ZenLib/ModelChecking/ModelChecker.cs
@@ -6,7 +6,6 @@ namespace ZenLib.ModelChecking
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.Immutable;
     using ZenLib.Solver;
 
     /// <summary>
@@ -41,7 +40,7 @@ namespace ZenLib.ModelChecking
         ///     Assignment to zen arbitrary variables that make the expression false.
         ///     Null if no such assignment exists.
         /// </returns>
-        public Dictionary<object, object> ModelCheck(Zen<bool> expression, ImmutableDictionary<long, object> arguments)
+        public Dictionary<object, object> ModelCheck(Zen<bool> expression, Dictionary<long, object> arguments)
         {
             var symbolicEvaluator = new SymbolicEvaluationVisitor<TModel, TVar, TBool, TBitvec, TInt, TString>(solver);
             var env = new SymbolicEvaluationEnvironment<TModel, TVar, TBool, TBitvec, TInt, TString>(arguments);

--- a/ZenLib/ModelChecking/ModelCheckerFactory.cs
+++ b/ZenLib/ModelChecking/ModelCheckerFactory.cs
@@ -4,6 +4,7 @@
 
 namespace ZenLib.ModelChecking
 {
+    using System.Collections.Immutable;
     using DecisionDiagrams;
     using Microsoft.Z3;
     using ZenLib.Solver;
@@ -18,12 +19,13 @@ namespace ZenLib.ModelChecking
         /// </summary>
         /// <param name="backend">The backend to use.</param>
         /// <param name="expression">The expression to evaluate.</param>
+        /// <param name="arguments">The arguements.</param>
         /// <returns>A new model checker.</returns>
-        internal static IModelChecker CreateModelChecker(Backend backend, Zen<bool> expression)
+        internal static IModelChecker CreateModelChecker(Backend backend, Zen<bool> expression, ImmutableDictionary<long, object> arguments)
         {
             if (backend == Backend.DecisionDiagrams)
             {
-                return CreateModelCheckerDD(expression);
+                return CreateModelCheckerDD(expression, arguments);
             }
 
             return CreateModelCheckerZ3();
@@ -32,12 +34,13 @@ namespace ZenLib.ModelChecking
         /// <summary>
         /// Create a model checker based on decision diagrams.
         /// </summary>
-        /// <param name="expression"></param>
-        /// <returns></returns>
-        private static IModelChecker CreateModelCheckerDD(Zen<bool> expression)
+        /// <param name="expression">The expression.</param>
+        /// <param name="arguments">The arguments.</param>
+        /// <returns>A model checker.</returns>
+        private static IModelChecker CreateModelCheckerDD(Zen<bool> expression, ImmutableDictionary<long, object> arguments)
         {
             var heuristic = new InterleavingHeuristic();
-            var mustInterleave = heuristic.Compute(expression);
+            var mustInterleave = heuristic.Compute(expression, arguments);
             var manager = new DDManager<BDDNode>(new BDDNodeFactory());
             var solver = new SolverDD<BDDNode>(manager, mustInterleave);
             solver.Init();
@@ -47,7 +50,7 @@ namespace ZenLib.ModelChecking
         /// <summary>
         /// Create a model checker based on SMT with Z3.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A model checker.</returns>
         private static IModelChecker CreateModelCheckerZ3()
         {
             var solver = new SolverZ3();

--- a/ZenLib/ModelChecking/ModelCheckerFactory.cs
+++ b/ZenLib/ModelChecking/ModelCheckerFactory.cs
@@ -4,7 +4,7 @@
 
 namespace ZenLib.ModelChecking
 {
-    using System.Collections.Immutable;
+    using System.Collections.Generic;
     using DecisionDiagrams;
     using Microsoft.Z3;
     using ZenLib.Solver;
@@ -21,7 +21,7 @@ namespace ZenLib.ModelChecking
         /// <param name="expression">The expression to evaluate.</param>
         /// <param name="arguments">The arguements.</param>
         /// <returns>A new model checker.</returns>
-        internal static IModelChecker CreateModelChecker(Backend backend, Zen<bool> expression, ImmutableDictionary<long, object> arguments)
+        internal static IModelChecker CreateModelChecker(Backend backend, Zen<bool> expression, Dictionary<long, object> arguments)
         {
             if (backend == Backend.DecisionDiagrams)
             {
@@ -37,7 +37,7 @@ namespace ZenLib.ModelChecking
         /// <param name="expression">The expression.</param>
         /// <param name="arguments">The arguments.</param>
         /// <returns>A model checker.</returns>
-        private static IModelChecker CreateModelCheckerDD(Zen<bool> expression, ImmutableDictionary<long, object> arguments)
+        private static IModelChecker CreateModelCheckerDD(Zen<bool> expression, Dictionary<long, object> arguments)
         {
             var heuristic = new InterleavingHeuristic();
             var mustInterleave = heuristic.Compute(expression, arguments);

--- a/ZenLib/ModelChecking/StateSetTransformer.cs
+++ b/ZenLib/ModelChecking/StateSetTransformer.cs
@@ -6,6 +6,7 @@ namespace ZenLib.ModelChecking
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using DecisionDiagrams;
     using ZenLib.Solver;
 
@@ -91,7 +92,7 @@ namespace ZenLib.ModelChecking
             {
                 var expr = invariant(this.zenInput, this.zenOutput);
                 var symbolicEvaluator = new SymbolicEvaluationVisitor<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>(this.solver);
-                var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>();
+                var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>(ImmutableDictionary<long, object>.Empty);
                 var symbolicResult =
                     (SymbolicBool<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>)expr.Accept(symbolicEvaluator, env);
                 var ddOutput = symbolicResult.Value;
@@ -115,7 +116,7 @@ namespace ZenLib.ModelChecking
                 var expr = invariant(this.zenInput, this.zenOutput);
 
                 var symbolicEvaluator = new SymbolicEvaluationVisitor<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>(this.solver);
-                var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>();
+                var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>(ImmutableDictionary<long, object>.Empty);
                 var symbolicResult =
                     (SymbolicBool<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>)expr.Accept(symbolicEvaluator, env);
                 var ddInput = symbolicResult.Value;

--- a/ZenLib/ModelChecking/StateSetTransformer.cs
+++ b/ZenLib/ModelChecking/StateSetTransformer.cs
@@ -15,6 +15,8 @@ namespace ZenLib.ModelChecking
     /// </summary>
     public class StateSetTransformer<T1, T2>
     {
+        private static Dictionary<long, object> arguments = new Dictionary<long, object>();
+
         /// <summary>
         /// The underlying solver to use.
         /// </summary>
@@ -92,7 +94,7 @@ namespace ZenLib.ModelChecking
             {
                 var expr = invariant(this.zenInput, this.zenOutput);
                 var symbolicEvaluator = new SymbolicEvaluationVisitor<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>(this.solver);
-                var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>(ImmutableDictionary<long, object>.Empty);
+                var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>(arguments);
                 var symbolicResult =
                     (SymbolicBool<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>)expr.Accept(symbolicEvaluator, env);
                 var ddOutput = symbolicResult.Value;
@@ -116,7 +118,7 @@ namespace ZenLib.ModelChecking
                 var expr = invariant(this.zenInput, this.zenOutput);
 
                 var symbolicEvaluator = new SymbolicEvaluationVisitor<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>(this.solver);
-                var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>(ImmutableDictionary<long, object>.Empty);
+                var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>(arguments);
                 var symbolicResult =
                     (SymbolicBool<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>)expr.Accept(symbolicEvaluator, env);
                 var ddInput = symbolicResult.Value;

--- a/ZenLib/ModelChecking/StateSetTransformerFactory.cs
+++ b/ZenLib/ModelChecking/StateSetTransformerFactory.cs
@@ -6,6 +6,7 @@ namespace ZenLib.ModelChecking
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Linq;
     using DecisionDiagrams;
     using ZenLib.Generation;
@@ -51,7 +52,7 @@ namespace ZenLib.ModelChecking
 
             // initialize the decision diagram solver
             var heuristic = new InterleavingHeuristic();
-            var mustInterleave = heuristic.Compute(newExpression);
+            var mustInterleave = heuristic.Compute(newExpression, ImmutableDictionary<long, object>.Empty);
 
             var solver = new SolverDD<BDDNode>(manager.DecisionDiagramManager, mustInterleave);
 
@@ -83,7 +84,7 @@ namespace ZenLib.ModelChecking
 
             // get the decision diagram representing the equality.
             var symbolicEvaluator = new SymbolicEvaluationVisitor<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>(solver);
-            var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>();
+            var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>(ImmutableDictionary<long, object>.Empty);
             var symbolicValue = newExpression.Accept(symbolicEvaluator, env);
             var symbolicResult = (SymbolicBool<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>)symbolicValue;
 

--- a/ZenLib/ModelChecking/StateSetTransformerFactory.cs
+++ b/ZenLib/ModelChecking/StateSetTransformerFactory.cs
@@ -6,7 +6,6 @@ namespace ZenLib.ModelChecking
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.Immutable;
     using System.Linq;
     using DecisionDiagrams;
     using ZenLib.Generation;
@@ -17,6 +16,8 @@ namespace ZenLib.ModelChecking
     /// </summary>
     internal static class StateSetTransformerFactory
     {
+        private static Dictionary<long, object> arguments = new Dictionary<long, object>();
+
         /// <summary>
         ///     Default manager object will allocate all objects.
         /// </summary>
@@ -52,7 +53,7 @@ namespace ZenLib.ModelChecking
 
             // initialize the decision diagram solver
             var heuristic = new InterleavingHeuristic();
-            var mustInterleave = heuristic.Compute(newExpression, ImmutableDictionary<long, object>.Empty);
+            var mustInterleave = heuristic.Compute(newExpression, arguments);
 
             var solver = new SolverDD<BDDNode>(manager.DecisionDiagramManager, mustInterleave);
 
@@ -84,7 +85,7 @@ namespace ZenLib.ModelChecking
 
             // get the decision diagram representing the equality.
             var symbolicEvaluator = new SymbolicEvaluationVisitor<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>(solver);
-            var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>(ImmutableDictionary<long, object>.Empty);
+            var env = new SymbolicEvaluationEnvironment<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>(arguments);
             var symbolicValue = newExpression.Accept(symbolicEvaluator, env);
             var symbolicResult = (SymbolicBool<Assignment<BDDNode>, Variable<BDDNode>, DD, BitVector<BDDNode>, Unit, Unit>)symbolicValue;
 

--- a/ZenLib/ModelChecking/SymbolicEvaluationEnvironment.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluationEnvironment.cs
@@ -4,6 +4,7 @@
 
 namespace ZenLib.ModelChecking
 {
+    using System.Collections.Generic;
     using System.Collections.Immutable;
 
     /// <summary>
@@ -14,7 +15,7 @@ namespace ZenLib.ModelChecking
         /// <summary>
         /// Initializes a new instance of the class.
         /// </summary>
-        public SymbolicEvaluationEnvironment(ImmutableDictionary<long, object> argumentsToExpr)
+        public SymbolicEvaluationEnvironment(Dictionary<long, object> argumentsToExpr)
         {
             this.ArgumentsToExpr = argumentsToExpr;
             this.ArgumentsToValue = ImmutableDictionary<long, SymbolicValue<TModel, TVar, TBool, TBitvec, TInt, TString>>.Empty;
@@ -26,7 +27,7 @@ namespace ZenLib.ModelChecking
         /// <param name="argumentsToExpr">The arguments to expr assignment.</param>
         /// <param name="argumentAssignment">The initial argument assignment.</param>
         public SymbolicEvaluationEnvironment(
-            ImmutableDictionary<long, object> argumentsToExpr,
+            Dictionary<long, object> argumentsToExpr,
             ImmutableDictionary<long, SymbolicValue<TModel, TVar, TBool, TBitvec, TInt, TString>> argumentAssignment)
         {
             this.ArgumentsToValue = argumentAssignment;
@@ -41,6 +42,6 @@ namespace ZenLib.ModelChecking
         /// <summary>
         /// Gets the argument to expression assignment.
         /// </summary>
-        public ImmutableDictionary<long, object> ArgumentsToExpr { get; }
+        public Dictionary<long, object> ArgumentsToExpr { get; }
     }
 }

--- a/ZenLib/ModelChecking/SymbolicEvaluationEnvironment.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluationEnvironment.cs
@@ -14,23 +14,33 @@ namespace ZenLib.ModelChecking
         /// <summary>
         /// Initializes a new instance of the class.
         /// </summary>
-        public SymbolicEvaluationEnvironment()
+        public SymbolicEvaluationEnvironment(ImmutableDictionary<long, object> argumentsToExpr)
         {
-            this.ArgumentAssignment = ImmutableDictionary<long, SymbolicValue<TModel, TVar, TBool, TBitvec, TInt, TString>>.Empty;
+            this.ArgumentsToExpr = argumentsToExpr;
+            this.ArgumentsToValue = ImmutableDictionary<long, SymbolicValue<TModel, TVar, TBool, TBitvec, TInt, TString>>.Empty;
         }
 
         /// <summary>
         /// Initializes a new instance of the  class.
         /// </summary>
+        /// <param name="argumentsToExpr">The arguments to expr assignment.</param>
         /// <param name="argumentAssignment">The initial argument assignment.</param>
-        public SymbolicEvaluationEnvironment(ImmutableDictionary<long, SymbolicValue<TModel, TVar, TBool, TBitvec, TInt, TString>> argumentAssignment)
+        public SymbolicEvaluationEnvironment(
+            ImmutableDictionary<long, object> argumentsToExpr,
+            ImmutableDictionary<long, SymbolicValue<TModel, TVar, TBool, TBitvec, TInt, TString>> argumentAssignment)
         {
-            this.ArgumentAssignment = argumentAssignment;
+            this.ArgumentsToValue = argumentAssignment;
+            this.ArgumentsToExpr = argumentsToExpr;
         }
 
         /// <summary>
-        /// Gets the argument assignment.
+        /// Gets the argument to value assignment.
         /// </summary>
-        public ImmutableDictionary<long, SymbolicValue<TModel, TVar, TBool, TBitvec, TInt, TString>> ArgumentAssignment { get; }
+        public ImmutableDictionary<long, SymbolicValue<TModel, TVar, TBool, TBitvec, TInt, TString>> ArgumentsToValue { get; }
+
+        /// <summary>
+        /// Gets the argument to expression assignment.
+        /// </summary>
+        public ImmutableDictionary<long, object> ArgumentsToExpr { get; }
     }
 }

--- a/ZenLib/ModelChecking/SymbolicEvaluator.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluator.cs
@@ -4,6 +4,7 @@
 
 namespace ZenLib.ModelChecking
 {
+    using System.Collections.Immutable;
     using ZenLib.Interpretation;
 
     /// <summary>
@@ -15,12 +16,13 @@ namespace ZenLib.ModelChecking
         /// Determine if an expression has a satisfying assignment.
         /// </summary>
         /// <param name="expression">The Zen expression for the function.</param>
+        /// <param name="arguments">The arguments.</param>
         /// <param name="backend">The backend to use.</param>
         /// <returns>True or false.</returns>
-        public static bool Find(Zen<bool> expression, Backend backend)
+        public static bool Find(Zen<bool> expression, ImmutableDictionary<long, object> arguments, Backend backend)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, expression);
-            var assignment = modelChecker.ModelCheck(expression);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, expression, arguments);
+            var assignment = modelChecker.ModelCheck(expression, arguments);
             return assignment != null;
         }
 
@@ -28,16 +30,18 @@ namespace ZenLib.ModelChecking
         /// Find an input to a function satisfying some condition.
         /// </summary>
         /// <param name="expression">The Zen expression for the function.</param>
+        /// <param name="arguments">The arguments.</param>
         /// <param name="input">The Zen expression for the input to the function.</param>
         /// <param name="backend">The backend to use.</param>
         /// <returns>An optional input value.</returns>
         public static Option<T> Find<T>(
             Zen<bool> expression,
+            ImmutableDictionary<long, object> arguments,
             Zen<T> input,
             Backend backend)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, expression);
-            var assignment = modelChecker.ModelCheck(expression);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, expression, arguments);
+            var assignment = modelChecker.ModelCheck(expression, arguments);
             if (assignment == null)
             {
                 return Option.None<T>();
@@ -52,19 +56,21 @@ namespace ZenLib.ModelChecking
         /// Find an input to a function satisfying some condition.
         /// </summary>
         /// <param name="expression">The Zen expression for the function.</param>
+        /// <param name="arguments">The arguments.</param>
         /// <param name="input1">The first Zen expression for the input to the function.</param>
         /// <param name="input2">The second Zen expression for the input to the function.</param>
         /// <param name="backend">The backend to use.</param>
         /// <returns>An optional input value.</returns>
         public static Option<(T1, T2)> Find<T1, T2>(
             Zen<bool> expression,
+            ImmutableDictionary<long, object> arguments,
             Zen<T1> input1,
             Zen<T2> input2,
             Backend backend)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, expression);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, expression, arguments);
 
-            var assignment = modelChecker.ModelCheck(expression);
+            var assignment = modelChecker.ModelCheck(expression, arguments);
 
             if (assignment == null)
             {
@@ -82,6 +88,7 @@ namespace ZenLib.ModelChecking
         /// Find an input to a function satisfying some condition.
         /// </summary>
         /// <param name="expression">The Zen expression for the function.</param>
+        /// <param name="arguments">The arguments.</param>
         /// <param name="input1">The first Zen expression for the input to the function.</param>
         /// <param name="input2">The second Zen expression for the input to the function.</param>
         /// <param name="input3">The third Zen expression for the input to the function.</param>
@@ -89,13 +96,14 @@ namespace ZenLib.ModelChecking
         /// <returns>An optional input value.</returns>
         public static Option<(T1, T2, T3)> Find<T1, T2, T3>(
             Zen<bool> expression,
+            ImmutableDictionary<long, object> arguments,
             Zen<T1> input1,
             Zen<T2> input2,
             Zen<T3> input3,
             Backend backend)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, expression);
-            var assignment = modelChecker.ModelCheck(expression);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, expression, arguments);
+            var assignment = modelChecker.ModelCheck(expression, arguments);
 
             if (assignment == null)
             {
@@ -115,6 +123,7 @@ namespace ZenLib.ModelChecking
         /// Find an input to a function satisfying some condition.
         /// </summary>
         /// <param name="expression">The Zen expression for the function.</param>
+        /// <param name="arguments">The arguments.</param>
         /// <param name="input1">The first Zen expression for the input to the function.</param>
         /// <param name="input2">The second Zen expression for the input to the function.</param>
         /// <param name="input3">The third Zen expression for the input to the function.</param>
@@ -123,14 +132,15 @@ namespace ZenLib.ModelChecking
         /// <returns>An optional input value.</returns>
         public static Option<(T1, T2, T3, T4)> Find<T1, T2, T3, T4>(
             Zen<bool> expression,
+            ImmutableDictionary<long, object> arguments,
             Zen<T1> input1,
             Zen<T2> input2,
             Zen<T3> input3,
             Zen<T4> input4,
             Backend backend)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, expression);
-            var assignment = modelChecker.ModelCheck(expression);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, expression, arguments);
+            var assignment = modelChecker.ModelCheck(expression, arguments);
 
             if (assignment == null)
             {

--- a/ZenLib/ModelChecking/SymbolicEvaluator.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluator.cs
@@ -4,7 +4,7 @@
 
 namespace ZenLib.ModelChecking
 {
-    using System.Collections.Immutable;
+    using System.Collections.Generic;
     using ZenLib.Interpretation;
 
     /// <summary>
@@ -19,7 +19,7 @@ namespace ZenLib.ModelChecking
         /// <param name="arguments">The arguments.</param>
         /// <param name="backend">The backend to use.</param>
         /// <returns>True or false.</returns>
-        public static bool Find(Zen<bool> expression, ImmutableDictionary<long, object> arguments, Backend backend)
+        public static bool Find(Zen<bool> expression, Dictionary<long, object> arguments, Backend backend)
         {
             var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, expression, arguments);
             var assignment = modelChecker.ModelCheck(expression, arguments);
@@ -36,7 +36,7 @@ namespace ZenLib.ModelChecking
         /// <returns>An optional input value.</returns>
         public static Option<T> Find<T>(
             Zen<bool> expression,
-            ImmutableDictionary<long, object> arguments,
+            Dictionary<long, object> arguments,
             Zen<T> input,
             Backend backend)
         {
@@ -63,7 +63,7 @@ namespace ZenLib.ModelChecking
         /// <returns>An optional input value.</returns>
         public static Option<(T1, T2)> Find<T1, T2>(
             Zen<bool> expression,
-            ImmutableDictionary<long, object> arguments,
+            Dictionary<long, object> arguments,
             Zen<T1> input1,
             Zen<T2> input2,
             Backend backend)
@@ -96,7 +96,7 @@ namespace ZenLib.ModelChecking
         /// <returns>An optional input value.</returns>
         public static Option<(T1, T2, T3)> Find<T1, T2, T3>(
             Zen<bool> expression,
-            ImmutableDictionary<long, object> arguments,
+            Dictionary<long, object> arguments,
             Zen<T1> input1,
             Zen<T2> input2,
             Zen<T3> input3,
@@ -132,7 +132,7 @@ namespace ZenLib.ModelChecking
         /// <returns>An optional input value.</returns>
         public static Option<(T1, T2, T3, T4)> Find<T1, T2, T3, T4>(
             Zen<bool> expression,
-            ImmutableDictionary<long, object> arguments,
+            Dictionary<long, object> arguments,
             Zen<T1> input1,
             Zen<T2> input2,
             Zen<T3> input3,

--- a/ZenLib/SymbolicExecution/InputGenerator.cs
+++ b/ZenLib/SymbolicExecution/InputGenerator.cs
@@ -6,6 +6,7 @@ namespace ZenLib.SymbolicExecution
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Linq;
     using ZenLib.Interpretation;
     using ZenLib.ModelChecking;
@@ -32,16 +33,17 @@ namespace ZenLib.SymbolicExecution
         {
             var expression = function(input).Simplify();
             var assume = precondition(input).Simplify();
+            var arguments = ImmutableDictionary<long, object>.Empty;
 
             (T2, PathConstraint) interpretFunction(T1 e)
             {
-                var assignment = ModelCheckerFactory.CreateModelChecker(backend, null).ModelCheck(input == e);
+                var assignment = ModelCheckerFactory.CreateModelChecker(backend, null, arguments).ModelCheck(input == e, arguments);
                 var evaluator = new ExpressionEvaluator(true);
                 var env = new ExpressionEvaluatorEnvironment(assignment);
                 return ((T2)expression.Accept(evaluator, env), evaluator.PathConstraint);
             }
 
-            Option<T1> findFunction(Zen<bool> e) => SymbolicEvaluator.Find(e, input, backend);
+            Option<T1> findFunction(Zen<bool> e) => SymbolicEvaluator.Find(e, arguments, input, backend);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }
@@ -64,18 +66,19 @@ namespace ZenLib.SymbolicExecution
         {
             var expression = function(input1, input2).Simplify();
             var assume = precondition(input1, input2).Simplify();
+            var arguments = ImmutableDictionary<long, object>.Empty;
 
             (T3, PathConstraint) interpretFunction((T1, T2) e)
             {
                 var assignment = ModelCheckerFactory
-                    .CreateModelChecker(backend, null)
-                    .ModelCheck(And(input1 == e.Item1, input2 == e.Item2));
+                    .CreateModelChecker(backend, null, arguments)
+                    .ModelCheck(And(input1 == e.Item1, input2 == e.Item2), arguments);
                 var evaluator = new ExpressionEvaluator(true);
                 var env = new ExpressionEvaluatorEnvironment(assignment);
                 return ((T3)expression.Accept(evaluator, env), evaluator.PathConstraint);
             }
 
-            Option<(T1, T2)> findFunction(Zen<bool> e) => SymbolicEvaluator.Find(e, input1, input2, backend);
+            Option<(T1, T2)> findFunction(Zen<bool> e) => SymbolicEvaluator.Find(e, arguments, input1, input2, backend);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }
@@ -100,18 +103,19 @@ namespace ZenLib.SymbolicExecution
         {
             var expression = function(input1, input2, input3).Simplify();
             var assume = precondition(input1, input2, input3).Simplify();
+            var arguments = ImmutableDictionary<long, object>.Empty;
 
             (T4, PathConstraint) interpretFunction((T1, T2, T3) e)
             {
                 var assignment = ModelCheckerFactory
-                    .CreateModelChecker(backend, null)
-                    .ModelCheck(And(input1 == e.Item1, input2 == e.Item2, input3 == e.Item3));
+                    .CreateModelChecker(backend, null, arguments)
+                    .ModelCheck(And(input1 == e.Item1, input2 == e.Item2, input3 == e.Item3), arguments);
                 var evaluator = new ExpressionEvaluator(true);
                 var env = new ExpressionEvaluatorEnvironment(assignment);
                 return ((T4)expression.Accept(evaluator, env), evaluator.PathConstraint);
             }
 
-            Option<(T1, T2, T3)> findFunction(Zen<bool> e) => SymbolicEvaluator.Find(e, input1, input2, input3, backend);
+            Option<(T1, T2, T3)> findFunction(Zen<bool> e) => SymbolicEvaluator.Find(e, arguments, input1, input2, input3, backend);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }
@@ -138,18 +142,19 @@ namespace ZenLib.SymbolicExecution
         {
             var expression = function(input1, input2, input3, input4).Simplify();
             var assume = precondition(input1, input2, input3, input4).Simplify();
+            var arguments = ImmutableDictionary<long, object>.Empty;
 
             (T5, PathConstraint) interpretFunction((T1, T2, T3, T4) e)
             {
                 var assignment = ModelCheckerFactory
-                    .CreateModelChecker(backend, null)
-                    .ModelCheck(And(input1 == e.Item1, input2 == e.Item2, input3 == e.Item3, input4 == e.Item4));
+                    .CreateModelChecker(backend, null, arguments)
+                    .ModelCheck(And(input1 == e.Item1, input2 == e.Item2, input3 == e.Item3, input4 == e.Item4), arguments);
                 var evaluator = new ExpressionEvaluator(true);
                 var env = new ExpressionEvaluatorEnvironment(assignment);
                 return ((T5)expression.Accept(evaluator, env), evaluator.PathConstraint);
             }
 
-            Option<(T1, T2, T3, T4)> findFunction(Zen<bool> e) => SymbolicEvaluator.Find(e, input1, input2, input3, input4, backend);
+            Option<(T1, T2, T3, T4)> findFunction(Zen<bool> e) => SymbolicEvaluator.Find(e, arguments, input1, input2, input3, input4, backend);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }

--- a/ZenLib/SymbolicExecution/InputGenerator.cs
+++ b/ZenLib/SymbolicExecution/InputGenerator.cs
@@ -17,6 +17,8 @@ namespace ZenLib.SymbolicExecution
     /// </summary>
     internal static class InputGenerator
     {
+        private static Dictionary<long, object> arguments = new Dictionary<long, object>();
+
         /// <summary>
         /// Generate inputs that exercise different program paths.
         /// </summary>
@@ -33,7 +35,6 @@ namespace ZenLib.SymbolicExecution
         {
             var expression = function(input).Simplify();
             var assume = precondition(input).Simplify();
-            var arguments = ImmutableDictionary<long, object>.Empty;
 
             (T2, PathConstraint) interpretFunction(T1 e)
             {
@@ -66,7 +67,6 @@ namespace ZenLib.SymbolicExecution
         {
             var expression = function(input1, input2).Simplify();
             var assume = precondition(input1, input2).Simplify();
-            var arguments = ImmutableDictionary<long, object>.Empty;
 
             (T3, PathConstraint) interpretFunction((T1, T2) e)
             {
@@ -103,7 +103,6 @@ namespace ZenLib.SymbolicExecution
         {
             var expression = function(input1, input2, input3).Simplify();
             var assume = precondition(input1, input2, input3).Simplify();
-            var arguments = ImmutableDictionary<long, object>.Empty;
 
             (T4, PathConstraint) interpretFunction((T1, T2, T3) e)
             {
@@ -142,7 +141,6 @@ namespace ZenLib.SymbolicExecution
         {
             var expression = function(input1, input2, input3, input4).Simplify();
             var assume = precondition(input1, input2, input3, input4).Simplify();
-            var arguments = ImmutableDictionary<long, object>.Empty;
 
             (T5, PathConstraint) interpretFunction((T1, T2, T3, T4) e)
             {

--- a/ZenLib/ZenFunction.cs
+++ b/ZenLib/ZenFunction.cs
@@ -99,14 +99,14 @@ namespace ZenLib
         private ZenArgumentExpr<T1> argument1;
 
         /// <summary>
-        /// The callback for the Zen function.
-        /// </summary>
-        private Func<Zen<T1>, Zen<T2>> function;
-
-        /// <summary>
         /// The expression for the function body.
         /// </summary>
         private Zen<T2> functionBodyExpr;
+
+        /// <summary>
+        /// The callback for the Zen function.
+        /// </summary>
+        private Func<Zen<T1>, Zen<T2>> function;
 
         /// <summary>
         /// The compiled C# version of the function.
@@ -267,8 +267,29 @@ namespace ZenLib
     /// <typeparam name="T3">Return type.</typeparam>
     public class ZenFunction<T1, T2, T3>
     {
+        /// <summary>
+        /// First argument expression.
+        /// </summary>
+        private ZenArgumentExpr<T1> argument1;
+
+        /// <summary>
+        /// Second argument expression.
+        /// </summary>
+        private ZenArgumentExpr<T2> argument2;
+
+        /// <summary>
+        /// Function body expression.
+        /// </summary>
+        private Zen<T3> functionBodyExpr;
+
+        /// <summary>
+        /// User provided function.
+        /// </summary>
         private Func<Zen<T1>, Zen<T2>, Zen<T3>> function;
 
+        /// <summary>
+        /// Compiled function to C# IL.
+        /// </summary>
         private Func<T1, T2, T3> compiledFunction = null;
 
         /// <summary>
@@ -288,6 +309,9 @@ namespace ZenLib
         {
             CommonUtilities.ValidateNotNull(function);
             this.function = function;
+            this.argument1 = new ZenArgumentExpr<T1>();
+            this.argument2 = new ZenArgumentExpr<T2>();
+            this.functionBodyExpr = this.function(this.argument1, this.argument2);
         }
 
         /// <summary>
@@ -351,17 +375,15 @@ namespace ZenLib
             bool checkSmallerLists = true,
             Backend backend = Backend.Z3)
         {
-            var arg1 = new ZenArgumentExpr<T1>();
-            var arg2 = new ZenArgumentExpr<T2>();
             input1 = CommonUtilities.GetArbitraryIfNull(input1, listSize, checkSmallerLists);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, listSize, checkSmallerLists);
             var args = new Dictionary<long, object>
             {
-                { arg1.ArgumentId, input1 },
-                { arg2.ArgumentId, input2 },
+                { this.argument1.ArgumentId, input1 },
+                { this.argument2.ArgumentId, input2 },
             };
 
-            var result = invariant(arg1, arg2, this.function(arg1, arg2));
+            var result = invariant(this.argument1, this.argument2, this.functionBodyExpr);
             return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input1, input2, backend));
         }
 
@@ -438,8 +460,34 @@ namespace ZenLib
     /// <typeparam name="T4">Return type.</typeparam>
     public class ZenFunction<T1, T2, T3, T4>
     {
+        /// <summary>
+        /// First argument expression.
+        /// </summary>
+        private ZenArgumentExpr<T1> argument1;
+
+        /// <summary>
+        /// Second argument expression.
+        /// </summary>
+        private ZenArgumentExpr<T2> argument2;
+
+        /// <summary>
+        /// Third argument expression.
+        /// </summary>
+        private ZenArgumentExpr<T3> argument3;
+
+        /// <summary>
+        /// Function body expression.
+        /// </summary>
+        private Zen<T4> functionBodyExpr;
+
+        /// <summary>
+        /// User-provided function.
+        /// </summary>
         private Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>> function;
 
+        /// <summary>
+        /// Compiled function as C# IL.
+        /// </summary>
         private Func<T1, T2, T3, T4> compiledFunction = null;
 
         /// <summary>
@@ -459,6 +507,10 @@ namespace ZenLib
         {
             CommonUtilities.ValidateNotNull(function);
             this.function = function;
+            this.argument1 = new ZenArgumentExpr<T1>();
+            this.argument2 = new ZenArgumentExpr<T2>();
+            this.argument3 = new ZenArgumentExpr<T3>();
+            this.functionBodyExpr = this.function(this.argument1, this.argument2, this.argument3);
         }
 
         /// <summary>
@@ -525,20 +577,17 @@ namespace ZenLib
             bool checkSmallerLists = true,
             Backend backend = Backend.Z3)
         {
-            var arg1 = new ZenArgumentExpr<T1>();
-            var arg2 = new ZenArgumentExpr<T2>();
-            var arg3 = new ZenArgumentExpr<T3>();
             input1 = CommonUtilities.GetArbitraryIfNull(input1, listSize, checkSmallerLists);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, listSize, checkSmallerLists);
             input3 = CommonUtilities.GetArbitraryIfNull(input3, listSize, checkSmallerLists);
             var args = new Dictionary<long, object>
             {
-                { arg1.ArgumentId, input1 },
-                { arg2.ArgumentId, input2 },
-                { arg3.ArgumentId, input3 },
+                { this.argument1.ArgumentId, input1 },
+                { this.argument2.ArgumentId, input2 },
+                { this.argument3.ArgumentId, input3 },
             };
 
-            var result = invariant(arg1, arg2, arg3, this.function(arg1, arg2, arg3));
+            var result = invariant(this.argument1, this.argument2, this.argument3, this.functionBodyExpr);
             return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input1, input2, input3, backend));
         }
 
@@ -622,8 +671,39 @@ namespace ZenLib
     /// <typeparam name="T5">Return type.</typeparam>
     public class ZenFunction<T1, T2, T3, T4, T5>
     {
+        /// <summary>
+        /// First argument expression.
+        /// </summary>
+        private ZenArgumentExpr<T1> argument1;
+
+        /// <summary>
+        /// Second argument expression.
+        /// </summary>
+        private ZenArgumentExpr<T2> argument2;
+
+        /// <summary>
+        /// Third argument expression.
+        /// </summary>
+        private ZenArgumentExpr<T3> argument3;
+
+        /// <summary>
+        /// Fourth argument expression.
+        /// </summary>
+        private ZenArgumentExpr<T4> argument4;
+
+        /// <summary>
+        /// Function body expression.
+        /// </summary>
+        private Zen<T5> functionBodyExpr;
+
+        /// <summary>
+        /// User-provided function.
+        /// </summary>
         private Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<T5>> function;
 
+        /// <summary>
+        /// Compiled function as C# IL.
+        /// </summary>
         private Func<T1, T2, T3, T4, T5> compiledFunction = null;
 
         /// <summary>
@@ -643,6 +723,11 @@ namespace ZenLib
         {
             CommonUtilities.ValidateNotNull(function);
             this.function = function;
+            this.argument1 = new ZenArgumentExpr<T1>();
+            this.argument2 = new ZenArgumentExpr<T2>();
+            this.argument3 = new ZenArgumentExpr<T3>();
+            this.argument4 = new ZenArgumentExpr<T4>();
+            this.functionBodyExpr = this.function(this.argument1, this.argument2, this.argument3, this.argument4);
         }
 
         /// <summary>
@@ -712,23 +797,19 @@ namespace ZenLib
             bool checkSmallerLists = true,
             Backend backend = Backend.Z3)
         {
-            var arg1 = new ZenArgumentExpr<T1>();
-            var arg2 = new ZenArgumentExpr<T2>();
-            var arg3 = new ZenArgumentExpr<T3>();
-            var arg4 = new ZenArgumentExpr<T4>();
             input1 = CommonUtilities.GetArbitraryIfNull(input1, listSize, checkSmallerLists);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, listSize, checkSmallerLists);
             input3 = CommonUtilities.GetArbitraryIfNull(input3, listSize, checkSmallerLists);
             input4 = CommonUtilities.GetArbitraryIfNull(input4, listSize, checkSmallerLists);
             var args = new Dictionary<long, object>
             {
-                { arg1.ArgumentId, input1 },
-                { arg2.ArgumentId, input2 },
-                { arg3.ArgumentId, input3 },
-                { arg4.ArgumentId, input4 },
+                { this.argument1.ArgumentId, input1 },
+                { this.argument2.ArgumentId, input2 },
+                { this.argument3.ArgumentId, input3 },
+                { this.argument4.ArgumentId, input4 },
             };
 
-            var result = invariant(arg1, arg2, arg3, arg4, this.function(arg1, arg2, arg3, arg4));
+            var result = invariant(this.argument1, this.argument2, this.argument3, this.argument4, this.functionBodyExpr);
             return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input1, input2, input3, input4, backend));
         }
 

--- a/ZenLib/ZenFunction.cs
+++ b/ZenLib/ZenFunction.cs
@@ -82,7 +82,7 @@ namespace ZenLib
         public bool Assert(Func<Zen<T>, Zen<bool>> invariant, Backend backend = Backend.Z3)
         {
             var result = invariant(this.function());
-            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, ImmutableDictionary<long, object>.Empty, backend));
+            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, new Dictionary<long, object>(), backend));
         }
     }
 
@@ -94,9 +94,19 @@ namespace ZenLib
     public class ZenFunction<T1, T2>
     {
         /// <summary>
+        /// First argument expression.
+        /// </summary>
+        private ZenArgumentExpr<T1> argument1;
+
+        /// <summary>
         /// The callback for the Zen function.
         /// </summary>
         private Func<Zen<T1>, Zen<T2>> function;
+
+        /// <summary>
+        /// The expression for the function body.
+        /// </summary>
+        private Zen<T2> functionBodyExpr;
 
         /// <summary>
         /// The compiled C# version of the function.
@@ -120,6 +130,8 @@ namespace ZenLib
         {
             CommonUtilities.ValidateNotNull(function);
             this.function = function;
+            this.argument1 = new ZenArgumentExpr<T1>();
+            this.functionBodyExpr = this.function(this.argument1);
         }
 
         /// <summary>
@@ -180,10 +192,13 @@ namespace ZenLib
             bool checkSmallerLists = true,
             Backend backend = Backend.Z3)
         {
-            var arg1 = new ZenArgumentExpr<T1>();
             input = CommonUtilities.GetArbitraryIfNull(input, listSize, checkSmallerLists);
-            var args = ImmutableDictionary<long, object>.Empty.Add(arg1.ArgumentId, input);
-            var result = invariant(arg1, this.function(arg1));
+            var args = new Dictionary<long, object>
+            {
+                { this.argument1.ArgumentId, input },
+            };
+
+            var result = invariant(this.argument1, this.functionBodyExpr);
             return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input, backend));
         }
 
@@ -211,7 +226,7 @@ namespace ZenLib
             while (true)
             {
                 var expr = And(result, Not(blocking));
-                var example = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(expr, ImmutableDictionary<long, object>.Empty, input, backend));
+                var example = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(expr, new Dictionary<long, object>(), input, backend));
                 if (!example.HasValue)
                 {
                     yield break;
@@ -340,9 +355,12 @@ namespace ZenLib
             var arg2 = new ZenArgumentExpr<T2>();
             input1 = CommonUtilities.GetArbitraryIfNull(input1, listSize, checkSmallerLists);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, listSize, checkSmallerLists);
-            var args = ImmutableDictionary<long, object>.Empty
-                .Add(arg1.ArgumentId, input1)
-                .Add(arg2.ArgumentId, input2);
+            var args = new Dictionary<long, object>
+            {
+                { arg1.ArgumentId, input1 },
+                { arg2.ArgumentId, input2 },
+            };
+
             var result = invariant(arg1, arg2, this.function(arg1, arg2));
             return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input1, input2, backend));
         }
@@ -375,7 +393,7 @@ namespace ZenLib
             {
                 var expr = And(result, Not(blocking));
                 var example = CommonUtilities.RunWithLargeStack(
-                    () => SymbolicEvaluator.Find(expr, ImmutableDictionary<long, object>.Empty, input1, input2, backend));
+                    () => SymbolicEvaluator.Find(expr, new Dictionary<long, object>(), input1, input2, backend));
                 if (!example.HasValue)
                 {
                     yield break;
@@ -513,10 +531,13 @@ namespace ZenLib
             input1 = CommonUtilities.GetArbitraryIfNull(input1, listSize, checkSmallerLists);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, listSize, checkSmallerLists);
             input3 = CommonUtilities.GetArbitraryIfNull(input3, listSize, checkSmallerLists);
-            var args = ImmutableDictionary<long, object>.Empty
-                .Add(arg1.ArgumentId, input1)
-                .Add(arg2.ArgumentId, input2)
-                .Add(arg3.ArgumentId, input3);
+            var args = new Dictionary<long, object>
+            {
+                { arg1.ArgumentId, input1 },
+                { arg2.ArgumentId, input2 },
+                { arg3.ArgumentId, input3 },
+            };
+
             var result = invariant(arg1, arg2, arg3, this.function(arg1, arg2, arg3));
             return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input1, input2, input3, backend));
         }
@@ -552,7 +573,7 @@ namespace ZenLib
             {
                 var expr = And(result, Not(blocking));
                 var example = CommonUtilities.RunWithLargeStack(
-                    () => SymbolicEvaluator.Find(expr, ImmutableDictionary<long, object>.Empty, input1, input2, input3, backend));
+                    () => SymbolicEvaluator.Find(expr, new Dictionary<long, object>(), input1, input2, input3, backend));
                 if (!example.HasValue)
                 {
                     yield break;
@@ -699,11 +720,14 @@ namespace ZenLib
             input2 = CommonUtilities.GetArbitraryIfNull(input2, listSize, checkSmallerLists);
             input3 = CommonUtilities.GetArbitraryIfNull(input3, listSize, checkSmallerLists);
             input4 = CommonUtilities.GetArbitraryIfNull(input4, listSize, checkSmallerLists);
-            var args = ImmutableDictionary<long, object>.Empty
-                .Add(arg1.ArgumentId, input1)
-                .Add(arg2.ArgumentId, input2)
-                .Add(arg3.ArgumentId, input3)
-                .Add(arg4.ArgumentId, input4);
+            var args = new Dictionary<long, object>
+            {
+                { arg1.ArgumentId, input1 },
+                { arg2.ArgumentId, input2 },
+                { arg3.ArgumentId, input3 },
+                { arg4.ArgumentId, input4 },
+            };
+
             var result = invariant(arg1, arg2, arg3, arg4, this.function(arg1, arg2, arg3, arg4));
             return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input1, input2, input3, input4, backend));
         }
@@ -742,7 +766,7 @@ namespace ZenLib
             {
                 var expr = And(result, Not(blocking));
                 var example = CommonUtilities.RunWithLargeStack(
-                    () => SymbolicEvaluator.Find(expr, ImmutableDictionary<long, object>.Empty, input1, input2, input3, input4, backend));
+                    () => SymbolicEvaluator.Find(expr, new Dictionary<long, object>(), input1, input2, input3, input4, backend));
                 if (!example.HasValue)
                 {
                     yield break;

--- a/ZenLib/ZenFunction.cs
+++ b/ZenLib/ZenFunction.cs
@@ -6,6 +6,7 @@ namespace ZenLib
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using ZenLib.Compilation;
     using ZenLib.Interpretation;
     using ZenLib.ModelChecking;
@@ -81,7 +82,7 @@ namespace ZenLib
         public bool Assert(Func<Zen<T>, Zen<bool>> invariant, Backend backend = Backend.Z3)
         {
             var result = invariant(this.function());
-            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, backend));
+            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, ImmutableDictionary<long, object>.Empty, backend));
         }
     }
 
@@ -179,9 +180,11 @@ namespace ZenLib
             bool checkSmallerLists = true,
             Backend backend = Backend.Z3)
         {
+            var arg1 = new ZenArgumentExpr<T1>();
             input = CommonUtilities.GetArbitraryIfNull(input, listSize, checkSmallerLists);
-            var result = invariant(input, this.function(input));
-            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, input, backend));
+            var args = ImmutableDictionary<long, object>.Empty.Add(arg1.ArgumentId, input);
+            var result = invariant(arg1, this.function(arg1));
+            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input, backend));
         }
 
         /// <summary>
@@ -208,7 +211,7 @@ namespace ZenLib
             while (true)
             {
                 var expr = And(result, Not(blocking));
-                var example = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(expr, input, backend));
+                var example = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(expr, ImmutableDictionary<long, object>.Empty, input, backend));
                 if (!example.HasValue)
                 {
                     yield break;
@@ -333,10 +336,15 @@ namespace ZenLib
             bool checkSmallerLists = true,
             Backend backend = Backend.Z3)
         {
+            var arg1 = new ZenArgumentExpr<T1>();
+            var arg2 = new ZenArgumentExpr<T2>();
             input1 = CommonUtilities.GetArbitraryIfNull(input1, listSize, checkSmallerLists);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, listSize, checkSmallerLists);
-            var result = invariant(input1, input2, this.function(input1, input2));
-            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, input1, input2, backend));
+            var args = ImmutableDictionary<long, object>.Empty
+                .Add(arg1.ArgumentId, input1)
+                .Add(arg2.ArgumentId, input2);
+            var result = invariant(arg1, arg2, this.function(arg1, arg2));
+            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input1, input2, backend));
         }
 
         /// <summary>
@@ -366,7 +374,8 @@ namespace ZenLib
             while (true)
             {
                 var expr = And(result, Not(blocking));
-                var example = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(expr, input1, input2, backend));
+                var example = CommonUtilities.RunWithLargeStack(
+                    () => SymbolicEvaluator.Find(expr, ImmutableDictionary<long, object>.Empty, input1, input2, backend));
                 if (!example.HasValue)
                 {
                     yield break;
@@ -498,11 +507,18 @@ namespace ZenLib
             bool checkSmallerLists = true,
             Backend backend = Backend.Z3)
         {
+            var arg1 = new ZenArgumentExpr<T1>();
+            var arg2 = new ZenArgumentExpr<T2>();
+            var arg3 = new ZenArgumentExpr<T3>();
             input1 = CommonUtilities.GetArbitraryIfNull(input1, listSize, checkSmallerLists);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, listSize, checkSmallerLists);
             input3 = CommonUtilities.GetArbitraryIfNull(input3, listSize, checkSmallerLists);
-            var result = invariant(input1, input2, input3, this.function(input1, input2, input3));
-            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, input1, input2, input3, backend));
+            var args = ImmutableDictionary<long, object>.Empty
+                .Add(arg1.ArgumentId, input1)
+                .Add(arg2.ArgumentId, input2)
+                .Add(arg3.ArgumentId, input3);
+            var result = invariant(arg1, arg2, arg3, this.function(arg1, arg2, arg3));
+            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input1, input2, input3, backend));
         }
 
         /// <summary>
@@ -535,7 +551,8 @@ namespace ZenLib
             while (true)
             {
                 var expr = And(result, Not(blocking));
-                var example = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(expr, input1, input2, input3, backend));
+                var example = CommonUtilities.RunWithLargeStack(
+                    () => SymbolicEvaluator.Find(expr, ImmutableDictionary<long, object>.Empty, input1, input2, input3, backend));
                 if (!example.HasValue)
                 {
                     yield break;
@@ -674,12 +691,21 @@ namespace ZenLib
             bool checkSmallerLists = true,
             Backend backend = Backend.Z3)
         {
+            var arg1 = new ZenArgumentExpr<T1>();
+            var arg2 = new ZenArgumentExpr<T2>();
+            var arg3 = new ZenArgumentExpr<T3>();
+            var arg4 = new ZenArgumentExpr<T4>();
             input1 = CommonUtilities.GetArbitraryIfNull(input1, listSize, checkSmallerLists);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, listSize, checkSmallerLists);
             input3 = CommonUtilities.GetArbitraryIfNull(input3, listSize, checkSmallerLists);
             input4 = CommonUtilities.GetArbitraryIfNull(input4, listSize, checkSmallerLists);
-            var result = invariant(input1, input2, input3, input4, this.function(input1, input2, input3, input4));
-            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, input1, input2, input3, input4, backend));
+            var args = ImmutableDictionary<long, object>.Empty
+                .Add(arg1.ArgumentId, input1)
+                .Add(arg2.ArgumentId, input2)
+                .Add(arg3.ArgumentId, input3)
+                .Add(arg4.ArgumentId, input4);
+            var result = invariant(arg1, arg2, arg3, arg4, this.function(arg1, arg2, arg3, arg4));
+            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input1, input2, input3, input4, backend));
         }
 
         /// <summary>
@@ -715,7 +741,8 @@ namespace ZenLib
             while (true)
             {
                 var expr = And(result, Not(blocking));
-                var example = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(expr, input1, input2, input3, input4, backend));
+                var example = CommonUtilities.RunWithLargeStack(
+                    () => SymbolicEvaluator.Find(expr, ImmutableDictionary<long, object>.Empty, input1, input2, input3, input4, backend));
                 if (!example.HasValue)
                 {
                     yield break;

--- a/ZenLib/ZenFunction.cs
+++ b/ZenLib/ZenFunction.cs
@@ -239,14 +239,19 @@ namespace ZenLib
             Backend backend = Backend.Z3)
         {
             input = CommonUtilities.GetArbitraryIfNull(input, listSize, checkSmallerLists);
-            var result = invariant(input, this.function(input));
+            var args = new Dictionary<long, object>
+            {
+                { this.argument1.ArgumentId, input },
+            };
+
+            var result = invariant(input, this.functionBodyExpr);
 
             Zen<bool> blocking = false;
 
             while (true)
             {
                 var expr = And(result, Not(blocking));
-                var example = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(expr, new Dictionary<long, object>(), input, backend));
+                var example = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(expr, args, input, backend));
                 if (!example.HasValue)
                 {
                     yield break;
@@ -435,7 +440,13 @@ namespace ZenLib
         {
             input1 = CommonUtilities.GetArbitraryIfNull(input1, listSize, checkSmallerLists);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, listSize, checkSmallerLists);
-            var result = invariant(input1, input2, this.function(input1, input2));
+            var args = new Dictionary<long, object>
+            {
+                { this.argument1.ArgumentId, input1 },
+                { this.argument2.ArgumentId, input2 },
+            };
+
+            var result = invariant(input1, input2, this.functionBodyExpr);
 
             Zen<bool> blocking = false;
 
@@ -443,7 +454,7 @@ namespace ZenLib
             {
                 var expr = And(result, Not(blocking));
                 var example = CommonUtilities.RunWithLargeStack(
-                    () => SymbolicEvaluator.Find(expr, new Dictionary<long, object>(), input1, input2, backend));
+                    () => SymbolicEvaluator.Find(expr, args, input1, input2, backend));
                 if (!example.HasValue)
                 {
                     yield break;
@@ -653,7 +664,14 @@ namespace ZenLib
             input1 = CommonUtilities.GetArbitraryIfNull(input1, listSize, checkSmallerLists);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, listSize, checkSmallerLists);
             input3 = CommonUtilities.GetArbitraryIfNull(input3, listSize, checkSmallerLists);
-            var result = invariant(input1, input2, input3, this.function(input1, input2, input3));
+            var args = new Dictionary<long, object>
+            {
+                { this.argument1.ArgumentId, input1 },
+                { this.argument2.ArgumentId, input2 },
+                { this.argument3.ArgumentId, input3 },
+            };
+
+            var result = invariant(input1, input2, input3, this.functionBodyExpr);
 
             Zen<bool> blocking = false;
 
@@ -661,7 +679,7 @@ namespace ZenLib
             {
                 var expr = And(result, Not(blocking));
                 var example = CommonUtilities.RunWithLargeStack(
-                    () => SymbolicEvaluator.Find(expr, new Dictionary<long, object>(), input1, input2, input3, backend));
+                    () => SymbolicEvaluator.Find(expr, args, input1, input2, input3, backend));
                 if (!example.HasValue)
                 {
                     yield break;
@@ -892,7 +910,15 @@ namespace ZenLib
             input2 = CommonUtilities.GetArbitraryIfNull(input2, listSize, checkSmallerLists);
             input3 = CommonUtilities.GetArbitraryIfNull(input3, listSize, checkSmallerLists);
             input4 = CommonUtilities.GetArbitraryIfNull(input4, listSize, checkSmallerLists);
-            var result = invariant(input1, input2, input3, input4, this.function(input1, input2, input3, input4));
+            var args = new Dictionary<long, object>
+            {
+                { this.argument1.ArgumentId, input1 },
+                { this.argument2.ArgumentId, input2 },
+                { this.argument3.ArgumentId, input3 },
+                { this.argument4.ArgumentId, input4 },
+            };
+
+            var result = invariant(input1, input2, input3, input4, this.functionBodyExpr);
 
             Zen<bool> blocking = false;
 
@@ -900,7 +926,7 @@ namespace ZenLib
             {
                 var expr = And(result, Not(blocking));
                 var example = CommonUtilities.RunWithLargeStack(
-                    () => SymbolicEvaluator.Find(expr, new Dictionary<long, object>(), input1, input2, input3, input4, backend));
+                    () => SymbolicEvaluator.Find(expr, args, input1, input2, input3, input4, backend));
                 if (!example.HasValue)
                 {
                     yield break;

--- a/ZenLib/ZenFunction.cs
+++ b/ZenLib/ZenFunction.cs
@@ -19,8 +19,19 @@ namespace ZenLib
     /// <typeparam name="T">Return type.</typeparam>
     public class ZenFunction<T>
     {
+        /// <summary>
+        /// The function body expression.
+        /// </summary>
+        private Zen<T> functionBodyExpr;
+
+        /// <summary>
+        /// User provided function.
+        /// </summary>
         private Func<Zen<T>> function;
 
+        /// <summary>
+        /// The compiled function as C# IL.
+        /// </summary>
         private Func<T> compiledFunction = null;
 
         /// <summary>
@@ -40,6 +51,7 @@ namespace ZenLib
         {
             CommonUtilities.ValidateNotNull(function);
             this.function = function;
+            this.functionBodyExpr = this.function();
         }
 
         /// <summary>
@@ -53,7 +65,8 @@ namespace ZenLib
                 return compiledFunction();
             }
 
-            return CommonUtilities.RunWithLargeStack(() => Interpreter.Run(this.function).Item1);
+            var args = ImmutableDictionary<long, object>.Empty;
+            return CommonUtilities.RunWithLargeStack(() => Interpreter.Run(this.functionBodyExpr, args).Item1);
         }
 
         /// <summary>
@@ -146,7 +159,9 @@ namespace ZenLib
                 return compiledFunction(value);
             }
 
-            return CommonUtilities.RunWithLargeStack(() => Interpreter.Run(this.function, value).Item1);
+            var args = ImmutableDictionary<long, object>.Empty
+                .Add(this.argument1.ArgumentId, value);
+            return CommonUtilities.RunWithLargeStack(() => Interpreter.Run(this.functionBodyExpr, args).Item1);
         }
 
         /// <summary>
@@ -327,7 +342,10 @@ namespace ZenLib
                 return compiledFunction(value1, value2);
             }
 
-            return CommonUtilities.RunWithLargeStack(() => Interpreter.Run(this.function, value1, value2).Item1);
+            var args = ImmutableDictionary<long, object>.Empty
+                .Add(this.argument1.ArgumentId, value1)
+                .Add(this.argument2.ArgumentId, value2);
+            return CommonUtilities.RunWithLargeStack(() => Interpreter.Run(this.functionBodyExpr, args).Item1);
         }
 
         /// <summary>
@@ -527,7 +545,11 @@ namespace ZenLib
                 return compiledFunction(value1, value2, value3);
             }
 
-            return CommonUtilities.RunWithLargeStack(() => Interpreter.Run(this.function, value1, value2, value3).Item1);
+            var args = ImmutableDictionary<long, object>.Empty
+                .Add(this.argument1.ArgumentId, value1)
+                .Add(this.argument2.ArgumentId, value2)
+                .Add(this.argument3.ArgumentId, value3);
+            return CommonUtilities.RunWithLargeStack(() => Interpreter.Run(this.functionBodyExpr, args).Item1);
         }
 
         /// <summary>
@@ -745,7 +767,12 @@ namespace ZenLib
                 return compiledFunction(value1, value2, value3, value4);
             }
 
-            return CommonUtilities.RunWithLargeStack(() => Interpreter.Run(this.function, value1, value2, value3, value4).Item1);
+            var args = ImmutableDictionary<long, object>.Empty
+                .Add(this.argument1.ArgumentId, value1)
+                .Add(this.argument2.ArgumentId, value2)
+                .Add(this.argument3.ArgumentId, value3)
+                .Add(this.argument4.ArgumentId, value4);
+            return CommonUtilities.RunWithLargeStack(() => Interpreter.Run(this.functionBodyExpr, args).Item1);
         }
 
         /// <summary>

--- a/ZenLib/ZenFunction.cs
+++ b/ZenLib/ZenFunction.cs
@@ -7,6 +7,7 @@ namespace ZenLib
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.Linq.Expressions;
     using ZenLib.Compilation;
     using ZenLib.Interpretation;
     using ZenLib.ModelChecking;
@@ -82,7 +83,8 @@ namespace ZenLib
                 return;
             }
 
-            this.compiledFunction = CodeGenerator.Compile(this.function, maxUnrollingDepth);
+            var args = ImmutableDictionary<long, Expression>.Empty;
+            this.compiledFunction = CodeGenerator.Compile(this.functionBodyExpr, args, maxUnrollingDepth);
         }
 
         /// <summary>
@@ -177,7 +179,10 @@ namespace ZenLib
                 return;
             }
 
-            this.compiledFunction = CodeGenerator.Compile(this.function, maxUnrollingDepth);
+            var param1 = Expression.Parameter(typeof(T1));
+            var args = ImmutableDictionary<long, Expression>.Empty
+                .Add(this.argument1.ArgumentId, param1);
+            this.compiledFunction = CodeGenerator.Compile<T1, T2>(this.functionBodyExpr, args, param1, maxUnrollingDepth);
         }
 
         /// <summary>
@@ -361,7 +366,12 @@ namespace ZenLib
                 return;
             }
 
-            this.compiledFunction = CodeGenerator.Compile(this.function, maxUnrollingDepth);
+            var param1 = Expression.Parameter(typeof(T1));
+            var param2 = Expression.Parameter(typeof(T2));
+            var args = ImmutableDictionary<long, Expression>.Empty
+                .Add(this.argument1.ArgumentId, param1)
+                .Add(this.argument2.ArgumentId, param2);
+            this.compiledFunction = CodeGenerator.Compile<T1, T2, T3>(this.functionBodyExpr, args, param1, param2, maxUnrollingDepth);
         }
 
         /// <summary>
@@ -565,7 +575,14 @@ namespace ZenLib
                 return;
             }
 
-            this.compiledFunction = CodeGenerator.Compile(this.function, maxUnrollingDepth);
+            var param1 = Expression.Parameter(typeof(T1));
+            var param2 = Expression.Parameter(typeof(T2));
+            var param3 = Expression.Parameter(typeof(T3));
+            var args = ImmutableDictionary<long, Expression>.Empty
+                .Add(this.argument1.ArgumentId, param1)
+                .Add(this.argument2.ArgumentId, param2)
+                .Add(this.argument3.ArgumentId, param3);
+            this.compiledFunction = CodeGenerator.Compile<T1, T2, T3, T4>(this.functionBodyExpr, args, param1, param2, param3, maxUnrollingDepth);
         }
 
         /// <summary>
@@ -788,7 +805,16 @@ namespace ZenLib
                 return;
             }
 
-            this.compiledFunction = CodeGenerator.Compile(this.function, maxUnrollingDepth);
+            var param1 = Expression.Parameter(typeof(T1));
+            var param2 = Expression.Parameter(typeof(T2));
+            var param3 = Expression.Parameter(typeof(T3));
+            var param4 = Expression.Parameter(typeof(T4));
+            var args = ImmutableDictionary<long, Expression>.Empty
+                .Add(this.argument1.ArgumentId, param1)
+                .Add(this.argument2.ArgumentId, param2)
+                .Add(this.argument3.ArgumentId, param3)
+                .Add(this.argument4.ArgumentId, param4);
+            this.compiledFunction = CodeGenerator.Compile<T1, T2, T3, T4, T5>(this.functionBodyExpr, args, param1, param2, param3, param4, maxUnrollingDepth);
         }
 
         /// <summary>

--- a/ZenLibTests/ListTests.cs
+++ b/ZenLibTests/ListTests.cs
@@ -35,7 +35,7 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestListContainsVariable()
         {
-            CheckAgreement<IList<byte>, byte>((l, x) => l.Contains(x));
+            CheckAgreement<IList<byte>, byte>((l, x) => l.Contains(x), bddListSize: 2);
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestListSort()
         {
-            CheckAgreement<IList<int>>(l => l.Sort().IsSorted());
+            CheckAgreement<IList<int>>(l => l.Sort().IsSorted(), bddListSize: 1);
         }
 
         /// <summary>


### PR DESCRIPTION
The implementation currently rebuilds the entire AST when interpreting or symbolically analyzing the ZenFunction object. This PR avoids that work by instantiating the function once with ZenArgumentExpr values.