### PR TITLE
Zen fix stateset bug

### DIFF
--- a/ZenLib/CommonUtilities.cs
+++ b/ZenLib/CommonUtilities.cs
@@ -243,11 +243,13 @@ namespace ZenLib
         /// <summary>
         /// Converts a solver result back to a C# result.
         /// </summary>
-        /// <param name="value">The solver result..</param>
+        /// <param name="value">The solver result.</param>
         /// <returns>The C# value.</returns>
         public static T ConvertSymbolicResultToCSharp<T>(object value)
         {
-            if (value.GetType() == typeof(byte[]))
+            return (T)ConvertSymbolicResultToCSharp(typeof(T), value);
+
+            /* if (value.GetType() == typeof(byte[]))
             {
                 var type = typeof(T);
                 var c = type.GetConstructor(new Type[] { typeof(byte[]) });
@@ -255,7 +257,41 @@ namespace ZenLib
                 return (T)intObj;
             }
 
-            return (T)value;
+            return (T)value; */
+        }
+
+        /// <summary>
+        /// Converts a solver result back to a C# result.
+        /// </summary>
+        /// <param name="type">The type of the result.</param>
+        /// <param name="value">The solver result.</param>
+        /// <returns>The C# value.</returns>
+        public static object ConvertSymbolicResultToCSharp(Type type, object value)
+        {
+            var objType = value.GetType();
+
+            if (type.IsAssignableFrom(objType))
+            {
+                return value;
+            }
+            else if (type == typeof(ushort) && objType == typeof(short))
+            {
+                return (ushort)(short)value;
+            }
+            else if (type == typeof(uint) && objType == typeof(int))
+            {
+                return (uint)(int)value;
+            }
+            else if (type == typeof(ulong) && objType == typeof(long))
+            {
+                return (ulong)(long)value;
+            }
+            else if (ReflectionUtilities.IsFixedIntegerType(type))
+            {
+                return type.GetConstructor(new Type[] { typeof(byte[]) }).Invoke(new object[] { value });
+            }
+
+            throw new ZenException($"Internal error: invalid conversion of type {type} to {objType}");
         }
 
         /// <summary>

--- a/ZenLib/CommonUtilities.cs
+++ b/ZenLib/CommonUtilities.cs
@@ -248,16 +248,6 @@ namespace ZenLib
         public static T ConvertSymbolicResultToCSharp<T>(object value)
         {
             return (T)ConvertSymbolicResultToCSharp(typeof(T), value);
-
-            /* if (value.GetType() == typeof(byte[]))
-            {
-                var type = typeof(T);
-                var c = type.GetConstructor(new Type[] { typeof(byte[]) });
-                var intObj = c.Invoke(new object[] { (byte[])value });
-                return (T)intObj;
-            }
-
-            return (T)value; */
         }
 
         /// <summary>

--- a/ZenLib/ModelChecking/ModelChecker.cs
+++ b/ZenLib/ModelChecking/ModelChecker.cs
@@ -64,28 +64,8 @@ namespace ZenLib.ModelChecking
                 var variable = kv.Value;
                 var type = expr.GetType().GetGenericArgumentsCached()[0];
                 var obj = this.solver.Get(model, variable);
-
-                if (type == typeof(ushort))
-                {
-                    obj = (ushort)(short)obj;
-                }
-
-                if (type == typeof(uint))
-                {
-                    obj = (uint)(int)obj;
-                }
-
-                if (type == typeof(ulong))
-                {
-                    obj = (ulong)(long)obj;
-                }
-
-                if (ReflectionUtilities.IsFixedIntegerType(type))
-                {
-                    obj = type.GetConstructor(new Type[] { typeof(byte[]) }).Invoke(new object[] { obj });
-                }
-
-                arbitraryAssignment.Add(expr, obj);
+                var result = CommonUtilities.ConvertSymbolicResultToCSharp(type, obj);
+                arbitraryAssignment.Add(expr, result);
             }
 
             return arbitraryAssignment;

--- a/ZenLib/ModelChecking/StateSet.cs
+++ b/ZenLib/ModelChecking/StateSet.cs
@@ -150,8 +150,9 @@ namespace ZenLib.ModelChecking
             var assignment = new Dictionary<object, object>();
             foreach (var kv in this.ArbitraryMapping)
             {
+                var type = kv.Key.GetType().GetGenericArgumentsCached()[0];
                 var value = this.Solver.Get(model, kv.Value);
-                assignment[kv.Key] = value;
+                assignment[kv.Key] = CommonUtilities.ConvertSymbolicResultToCSharp(type, value);
             }
 
             var interpreterEnv = new ExpressionEvaluatorEnvironment(assignment);

--- a/ZenLib/ZenLib.csproj
+++ b/ZenLib/ZenLib.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/microsoft/Zen</RepositoryUrl>
     <Description>A library that simplifies building verification tools in .NET</Description>
     <PackageTags>zen zenlib modeling constraint solving verification smt solver binary decision diagrams diagram</PackageTags>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/ZenLibTests/ObjectTests.cs
+++ b/ZenLibTests/ObjectTests.cs
@@ -1022,6 +1022,31 @@ namespace ZenLib.Tests
             Assert.AreEqual(18, function.Evaluate(x, y).v33);
         }
 
+        /// <summary>
+        /// Test that objects work with variable width integers.
+        /// </summary>
+        [TestMethod]
+        public void TestObjectWithVariableWidthInteger1()
+        {
+            var function = new ZenConstraint<ObjectWithInt>(x => x.GetField<ObjectWithInt, UInt10>("Field1") == new UInt10(1));
+            var input = function.Find();
+            Assert.IsTrue(input.HasValue);
+            Assert.AreEqual(1L, input.Value.Field1.ToLong());
+        }
+
+        /// <summary>
+        /// Test that objects work with variable width integers.
+        /// </summary>
+        [TestMethod]
+        public void TestObjectWithVariableWidthInteger2()
+        {
+            var o1 = new ObjectWithInt { Field1 = new UInt10(0) };
+            var o2 = new ObjectWithInt { Field1 = new UInt10(1) };
+            var function = new ZenConstraint<ObjectWithInt>(x => x.GetField<ObjectWithInt, UInt10>("Field1") == new UInt10(1));
+            Assert.IsFalse(function.Evaluate(o1));
+            Assert.IsTrue(function.Evaluate(o2));
+        }
+
         private struct StructField1
         {
             public int Field1;

--- a/ZenLibTests/StateSetTests.cs
+++ b/ZenLibTests/StateSetTests.cs
@@ -4,6 +4,7 @@
 
 namespace ZenLib.Tests
 {
+    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Numerics;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -184,6 +185,18 @@ namespace ZenLib.Tests
         {
             var manager = new StateSetTransformerManager(0);
             new ZenFunction<IpHeader, bool>(p => And(p.GetDstIp().GetValue() <= 4, p.GetSrcIp().GetValue() <= 5)).StateSet(manager);
+        }
+
+        /// <summary>
+        /// Test a transformer over an object with a variable width integer field.
+        /// </summary>
+        [TestMethod]
+        public void TestTransformerObjectWithInt()
+        {
+            var manager = new StateSetTransformerManager(0);
+            var set = new ZenFunction<TestHelper.ObjectWithInt, bool>(o => o.GetField<TestHelper.ObjectWithInt, UInt10>("Field1") == new UInt10(1))
+                .StateSet(manager);
+            Assert.AreEqual(1L, set.Element().Field1.ToLong());
         }
 
         /// <summary>

--- a/ZenLibTests/TestHelper.cs
+++ b/ZenLibTests/TestHelper.cs
@@ -541,6 +541,11 @@ namespace ZenLib.Tests
             public int Field1;
         }
 
+        internal class ObjectWithInt
+        {
+            public UInt10 Field1;
+        }
+
         private class TestParameter
         {
             public Backend Backend { get; set; }

--- a/ZenLibTests/TransformerTests.cs
+++ b/ZenLibTests/TransformerTests.cs
@@ -247,6 +247,19 @@ namespace ZenLib.Tests
         }
 
         /// <summary>
+        /// Test a transformer over an object with a variable width integer field.
+        /// </summary>
+        [TestMethod]
+        public void TestTransformerObjectWithInt()
+        {
+            var manager = new StateSetTransformerManager(0);
+            var t = new ZenFunction<TestHelper.ObjectWithInt, bool>(o => o.GetField<TestHelper.ObjectWithInt, UInt10>("Field1") == new UInt10(1))
+                .Transformer(manager);
+            var set = t.InputSet((p, o) => o);
+            Assert.AreEqual(1L, set.Element().Field1.ToLong());
+        }
+
+        /// <summary>
         /// Test packet transformations.
         /// </summary>
         [TestMethod]


### PR DESCRIPTION
Fixes an issue, where embedding a variable width integer like `UInt128` would not work with the StateSet API due to not properly converting the result back to the appropriate C# type.