### PR TITLE
Zen fix option null bug

### DIFF
--- a/ZenLib/CommonUtilities.cs
+++ b/ZenLib/CommonUtilities.cs
@@ -12,7 +12,6 @@ namespace ZenLib
     using System.Numerics;
     using System.Text;
     using System.Threading;
-    using ExceptionDispatchInfo = System.Runtime.ExceptionServices.ExceptionDispatchInfo;
 
     /// <summary>
     /// A collection of common utility functions.

--- a/ZenLib/ModelChecking/ModelChecker.cs
+++ b/ZenLib/ModelChecking/ModelChecker.cs
@@ -47,14 +47,12 @@ namespace ZenLib.ModelChecking
             var symbolicResult =
                 (SymbolicBool<TModel, TVar, TBool, TBitvec, TInt, TString>)expression.Accept(symbolicEvaluator, env);
 
-            var possibleModel = solver.Satisfiable(symbolicResult.Value);
+            var model = solver.Satisfiable(symbolicResult.Value);
 
-            if (!possibleModel.HasValue)
+            if (model == null)
             {
                 return null;
             }
-
-            var model = possibleModel.Value;
 
             // compute the input given the assignment
             var arbitraryAssignment = new Dictionary<object, object>();

--- a/ZenLib/Solver/ISolver.cs
+++ b/ZenLib/Solver/ISolver.cs
@@ -426,7 +426,7 @@ namespace ZenLib.Solver
         /// </summary>
         /// <param name="x">The expression.</param>
         /// <returns>A model, if satisfiable.</returns>
-        Option<TModel> Satisfiable(TBool x);
+        TModel Satisfiable(TBool x);
 
         /// <summary>
         /// Get the value for a variable in a model.

--- a/ZenLib/Solver/SolverDD.cs
+++ b/ZenLib/Solver/SolverDD.cs
@@ -563,15 +563,9 @@ namespace ZenLib.Solver
             return this.Manager.Or(x, y);
         }
 
-        public Option<Assignment<T>> Satisfiable(DD x)
+        public Assignment<T> Satisfiable(DD x)
         {
-            var m = this.Manager.Sat(x);
-            if (m == null)
-            {
-                return Option.None<Assignment<T>>();
-            }
-
-            return Option.Some(m);
+            return this.Manager.Sat(x);
         }
 
         [ExcludeFromCodeCoverage]

--- a/ZenLib/Solver/SolverZ3.cs
+++ b/ZenLib/Solver/SolverZ3.cs
@@ -399,16 +399,16 @@ namespace ZenLib.Solver
             return bytes;
         }
 
-        public Option<Model> Satisfiable(BoolExpr x)
+        public Model Satisfiable(BoolExpr x)
         {
             this.solver.Assert(x);
             var status = this.solver.Check();
             if (status == Status.UNSATISFIABLE)
             {
-                return Option.None<Model>();
+                return null;
             }
 
-            return Option.Some(this.solver.Model);
+            return this.solver.Model;
         }
 
         public static void RemoveTrailingZeroes(ref byte[] array)

--- a/ZenLib/ZenLib.csproj
+++ b/ZenLib/ZenLib.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/microsoft/Zen</RepositoryUrl>
     <Description>A library that simplifies building verification tools in .NET</Description>
     <PackageTags>zen zenlib modeling constraint solving verification smt solver binary decision diagrams diagram</PackageTags>
-    <Version>1.3.1</Version>
+    <Version>1.3.2</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/ZenLibTests/ConversionTests.cs
+++ b/ZenLibTests/ConversionTests.cs
@@ -114,6 +114,15 @@ namespace ZenLib.Tests
         }
 
         /// <summary>
+        /// Test that converting an option constant works for None.
+        /// </summary>
+        [TestMethod]
+        public void TestConvertOptionConstantNone()
+        {
+            Zen<Option<Unit>> _ = Option.None<Unit>();
+        }
+
+        /// <summary>
         /// Test that converting a value with a null dictionary key does not work.
         /// </summary>
         [TestMethod]

--- a/ZenLibTests/ConversionTests.cs
+++ b/ZenLibTests/ConversionTests.cs
@@ -119,44 +119,41 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestConvertOptionConstantNone()
         {
-            Zen<Option<Unit>> _ = Option.None<Unit>();
+            Zen<Option<Unit>> x = Option.None<Unit>();
+            Assert.AreEqual(x, Null<Unit>());
+        }
+
+        /// <summary>
+        /// Test that converting an option constant works for Some.
+        /// </summary>
+        [TestMethod]
+        public void TestConvertOptionConstantSome()
+        {
+            Zen<Option<int>> x = Option.Some(3);
+            Assert.AreEqual(x, Some<int>(3));
         }
 
         /// <summary>
         /// Test that converting a value with a null dictionary key does not work.
         /// </summary>
         [TestMethod]
+        [ExpectedException(typeof(ZenException))]
         public void TestConvertNullListValue()
         {
-            try
-            {
-                IList<Object1> o = new List<Object1> { { null } };
-                var _ = Constant(o);
-                Assert.Fail();
-            }
-            catch (System.Reflection.TargetInvocationException e)
-            {
-                Assert.AreEqual(typeof(ZenException), e.InnerException.GetType());
-            }
+            IList<Object1> o = new List<Object1> { { null } };
+            var _ = Constant(o);
         }
 
         /// <summary>
         /// Test that converting a value with a null dictionary value does not work.
         /// </summary>
         [TestMethod]
+        [ExpectedException(typeof(ZenException))]
         public void TestConvertNullDictionaryValue()
         {
-            try
-            {
-                Dict<int, Object1> o = new Dict<int, Object1>();
-                o.Add(1, null);
-                var _ = Constant(o);
-                Assert.Fail();
-            }
-            catch (System.Reflection.TargetInvocationException e)
-            {
-                Assert.AreEqual(typeof(ZenException), e.InnerException.GetType());
-            }
+            Dict<int, Object1> o = new Dict<int, Object1>();
+            o.Add(1, null);
+            var _ = Constant(o);
         }
 
         /// <summary>

--- a/ZenLibTests/OptionTests.cs
+++ b/ZenLibTests/OptionTests.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib.Tests
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using ZenLib;


### PR DESCRIPTION
Fixes a bug that occurred when converting a C# value to a Zen value for an option type where the inner type is a class. The option would create a null inner value and this would trigger an exception when traversing the type recursively to build a Zen value.

The fix is to add a special case for Options to the conversion code.