### PR TITLE
Removes the dependency on the IDictionary and IList interfaces.

### DIFF
--- a/ZenLib/Common/CommonUtilities.cs
+++ b/ZenLib/Common/CommonUtilities.cs
@@ -94,7 +94,18 @@ namespace ZenLib
         /// </summary>
         /// <param name="list">The list.</param>
         /// <returns>The head and the rest of the list.</returns>
-        public static (T, IList<T>) SplitHead<T>(ImmutableList<T> list)
+        public static (T, FSeq<T>) SplitHead<T>(FSeq<T> list)
+        {
+            var (hd, tl) = SplitHeadHelper(list.Values);
+            return (hd, new FSeq<T>(tl));
+        }
+
+        /// <summary>
+        /// Split a list to peel off the first element.
+        /// </summary>
+        /// <param name="list">The list.</param>
+        /// <returns>The head and the rest of the list.</returns>
+        public static (T, ImmutableList<T>) SplitHeadHelper<T>(ImmutableList<T> list)
         {
             var hd = list[0];
             var tl = list.Count == 1 ? ImmutableList<T>.Empty : list.GetRange(1, list.Count - 1);

--- a/ZenLib/Common/CommonUtilities.cs
+++ b/ZenLib/Common/CommonUtilities.cs
@@ -7,10 +7,7 @@ namespace ZenLib
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.Diagnostics.Contracts;
-    using System.Globalization;
     using System.Linq;
-    using System.Text;
     using System.Threading;
 
     /// <summary>
@@ -123,34 +120,14 @@ namespace ZenLib
         }
 
         /// <summary>
-        /// Checks if two dictionaries are equal.
-        /// </summary>
-        /// <typeparam name="TKey">The dictionary key type.</typeparam>
-        /// <typeparam name="TValue">The dictionary value type.</typeparam>
-        /// <param name="dictionary1">The first dictionary.</param>
-        /// <param name="dictionary2">The second dictionary.</param>
-        /// <returns></returns>
-        public static bool DictionaryEquals<TKey, TValue>(IDictionary<TKey, TValue> dictionary1, IDictionary<TKey, TValue> dictionary2)
-        {
-            if (dictionary1.Count != dictionary2.Count)
-            {
-                return false;
-            }
-
-            var pairs1 = new HashSet<KeyValuePair<TKey, TValue>>(dictionary1);
-            var pairs2 = new HashSet<KeyValuePair<TKey, TValue>>(dictionary2);
-            return pairs1.SetEquals(pairs2);
-        }
-
-        /// <summary>
         /// Unions two dictionaries.
         /// </summary>
         /// <param name="dict1">A dictionary.</param>
         /// <param name="dict2">A dictionary.</param>
         /// <returns>The union of the two dictionaries.</returns>
-        public static ImmutableDictionary<T, SetUnit> DictionaryUnion<T>(IDictionary<T, SetUnit> dict1, IDictionary<T, SetUnit> dict2)
+        public static Map<T, SetUnit> DictionaryUnion<T>(Map<T, SetUnit> dict1, Map<T, SetUnit> dict2)
         {
-            return ImmutableDictionary<T, SetUnit>.Empty.AddRange(dict1.Union(dict2));
+            return new Map<T, SetUnit>(ImmutableDictionary<T, SetUnit>.Empty.AddRange(dict1.Values.Union(dict2.Values)));
         }
 
         /// <summary>
@@ -159,9 +136,9 @@ namespace ZenLib
         /// <param name="dict1">A dictionary.</param>
         /// <param name="dict2">A dictionary.</param>
         /// <returns>The intersection of the two dictionaries.</returns>
-        public static ImmutableDictionary<T, SetUnit> DictionaryIntersect<T>(IDictionary<T, SetUnit> dict1, IDictionary<T, SetUnit> dict2)
+        public static Map<T, SetUnit> DictionaryIntersect<T>(Map<T, SetUnit> dict1, Map<T, SetUnit> dict2)
         {
-            return ImmutableDictionary<T, SetUnit>.Empty.AddRange(dict1.Intersect(dict2));
+            return new Map<T, SetUnit>(ImmutableDictionary<T, SetUnit>.Empty.AddRange(dict1.Values.Intersect(dict2.Values)));
         }
 
         /// <summary>

--- a/ZenLib/Common/CommonUtilities.cs
+++ b/ZenLib/Common/CommonUtilities.cs
@@ -102,24 +102,6 @@ namespace ZenLib
         }
 
         /// <summary>
-        /// Gets a value from a dictionary if the key exists.
-        /// </summary>
-        /// <typeparam name="TKey">The dictionary key type.</typeparam>
-        /// <typeparam name="TValue">The dictionary value type.</typeparam>
-        /// <param name="dictionary">The dictionary.</param>
-        /// <param name="key">The key to lookup.</param>
-        /// <returns></returns>
-        public static Option<TValue> DictionaryGet<TKey, TValue>(IDictionary<TKey, TValue> dictionary, TKey key)
-        {
-            if (dictionary.TryGetValue(key, out var value))
-            {
-                return Option.Some(value);
-            }
-
-            return Option.None<TValue>();
-        }
-
-        /// <summary>
         /// Unions two dictionaries.
         /// </summary>
         /// <param name="dict1">A dictionary.</param>

--- a/ZenLib/Common/ITypeVisitor.cs
+++ b/ZenLib/Common/ITypeVisitor.cs
@@ -82,7 +82,7 @@ namespace ZenLib
         /// Visit the dictionary type.
         /// </summary>
         /// <returns>A value.</returns>
-        T VisitDictionary(Type dictionaryType, Type keyType, Type valueType, TParam parameter);
+        T VisitMap(Type dictionaryType, Type keyType, Type valueType, TParam parameter);
 
         /// <summary>
         /// Visit the sequence type.

--- a/ZenLib/Common/ReflectionUtilities.cs
+++ b/ZenLib/Common/ReflectionUtilities.cs
@@ -94,14 +94,9 @@ namespace ZenLib
         public readonly static Type MapType = typeof(Map<,>);
 
         /// <summary>
-        /// Type of an IList.
+        /// The type of fseq values.
         /// </summary>
-        public readonly static Type IListType = typeof(IList<>);
-
-        /// <summary>
-        /// Type of an List.
-        /// </summary>
-        public readonly static Type ListType = typeof(List<>);
+        public readonly static Type FSeqType = typeof(FSeq<>);
 
         /// <summary>
         /// Type of a fixed size integer.
@@ -306,18 +301,6 @@ namespace ZenLib
         }
 
         /// <summary>
-        /// Check if a type is an IList type.
-        /// </summary>
-        /// <param name="type">The type.</param>
-        /// <returns></returns>
-        public static bool IsIListType(Type type)
-        {
-            return type.IsInterface &&
-                   type.IsGenericType &&
-                   type.GetGenericTypeDefinitionCached() == IListType;
-        }
-
-        /// <summary>
         /// Check if a type is a Seq type.
         /// </summary>
         /// <param name="type">The type.</param>
@@ -335,6 +318,16 @@ namespace ZenLib
         public static bool IsMapType(Type type)
         {
             return type.IsGenericType && type.GetGenericTypeDefinitionCached() == MapType;
+        }
+
+        /// <summary>
+        /// Check if a type is a FSeq type.
+        /// </summary>
+        /// <param name="type">The type.</param>
+        /// <returns></returns>
+        public static bool IsFSeqType(Type type)
+        {
+            return type.IsGenericType && type.GetGenericTypeDefinitionCached() == FSeqType;
         }
 
         /// <summary>
@@ -656,10 +649,9 @@ namespace ZenLib
                 return c.Invoke(CommonUtilities.EmptyArray);
             }
 
-            if (IsIListType(type))
+            if (IsFSeqType(type))
             {
-                var innerType = type.GetGenericArgumentsCached()[0];
-                var c = ListType.MakeGenericType(innerType).GetConstructor(new Type[] { });
+                var c = type.GetConstructor(new Type[] { });
                 return c.Invoke(CommonUtilities.EmptyArray);
             }
 
@@ -727,7 +719,7 @@ namespace ZenLib
                 return visitor.VisitMap(type, keyType, valueType, parameter);
             }
 
-            if (IsIListType(type))
+            if (IsFSeqType(type))
             {
                 var t = type.GetGenericArgumentsCached()[0];
                 return visitor.VisitList(type, t, parameter);
@@ -781,12 +773,12 @@ namespace ZenLib
         /// </summary>
         /// <param name="value">The list value.</param>
         /// <returns>The Zen value representing the list.</returns>
-        internal static Zen<IList<T>> CreateZenListConstant<T>(IList<T> value)
+        internal static Zen<FSeq<T>> CreateZenListConstant<T>(FSeq<T> value)
         {
-            Zen<IList<T>> list = ZenListEmptyExpr<T>.Instance;
-            foreach (var elt in value.Reverse())
+            Zen<FSeq<T>> list = ZenListEmptyExpr<T>.Instance;
+            foreach (var elt in value.Values.Reverse())
             {
-                ReportIfNullConversionError(elt, "element", typeof(IList<T>));
+                ReportIfNullConversionError(elt, "element", typeof(FSeq<T>));
                 list = ZenListAddFrontExpr<T>.Create(list, elt);
             }
 
@@ -858,7 +850,7 @@ namespace ZenLib
                     return CreateZenSeqConstantMethod.MakeGenericMethod(innerType).Invoke(null, new object[] { value });
                 }
 
-                if (type.IsGenericType && typeArgs.Length == 1 && IListType.MakeGenericType(typeArgs[0]).IsAssignableFrom(type))
+                if (IsFSeqType(type))
                 {
                     var innerType = typeArgs[0];
                     return CreateZenListConstantMethod.MakeGenericMethod(innerType).Invoke(null, new object[] { value });

--- a/ZenLib/Compilation/ExpressionConverter.cs
+++ b/ZenLib/Compilation/ExpressionConverter.cs
@@ -579,7 +579,7 @@ namespace ZenLib.Compilation
             var key = Convert(expression.KeyExpr, parameter);
             var mapExpr = Expression.Convert(dict, typeof(Map<TKey, TValue>));
             var method = typeof(Map<TKey, TValue>).GetMethodCached("Get");
-            return Expression.Call(null, method, mapExpr, key);
+            return Expression.Call(mapExpr, method, key);
         }
 
         public Expression Visit<TKey>(ZenDictCombineExpr<TKey> expression, ExpressionConverterEnvironment parameter)

--- a/ZenLib/Generation/DefaultTypeGenerator.cs
+++ b/ZenLib/Generation/DefaultTypeGenerator.cs
@@ -62,7 +62,7 @@ namespace ZenLib.Generation
             return method.Invoke(null, CommonUtilities.EmptyArray);
         }
 
-        public object VisitDictionary(Type dictionaryType, Type keyType, Type valueType, Unit parameter)
+        public object VisitMap(Type dictionaryType, Type keyType, Type valueType, Unit parameter)
         {
             var method = emptyDictMethod.MakeGenericMethod(keyType, valueType);
             return method.Invoke(null, CommonUtilities.EmptyArray);

--- a/ZenLib/Generation/SymbolicInputGenerator.cs
+++ b/ZenLib/Generation/SymbolicInputGenerator.cs
@@ -104,7 +104,7 @@ namespace ZenLib.Generation
             return list;
         }
 
-        public object VisitDictionary(Type dictionaryType, Type keyType, Type valueType, ZenDepthConfiguration parameter)
+        public object VisitMap(Type dictionaryType, Type keyType, Type valueType, ZenDepthConfiguration parameter)
         {
             var method = arbitraryDictMethod.MakeGenericMethod(keyType, valueType);
             var e = method.Invoke(null, CommonUtilities.EmptyArray);

--- a/ZenLib/Interpretation/ExpressionEvaluator.cs
+++ b/ZenLib/Interpretation/ExpressionEvaluator.cs
@@ -4,6 +4,7 @@
 
 namespace ZenLib.Interpretation
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Numerics;

--- a/ZenLib/Interpretation/ExpressionEvaluator.cs
+++ b/ZenLib/Interpretation/ExpressionEvaluator.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib.Interpretation
 {
-    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Numerics;
@@ -198,11 +197,6 @@ namespace ZenLib.Interpretation
             return ReflectionUtilities.CreateInstance<TObject>(fieldNames.ToArray(), parameters.ToArray());
         }
 
-        public object Visit<T>(ZenListEmptyExpr<T> expression, ExpressionEvaluatorEnvironment parameter)
-        {
-            return ImmutableList<T>.Empty;
-        }
-
         public object Visit<T1, T2>(ZenGetFieldExpr<T1, T2> expression, ExpressionEvaluatorEnvironment parameter)
         {
             var e = (T1)Evaluate(expression.Expr, parameter);
@@ -291,18 +285,23 @@ namespace ZenLib.Interpretation
             }
         }
 
+        public object Visit<T>(ZenListEmptyExpr<T> expression, ExpressionEvaluatorEnvironment parameter)
+        {
+            return new FSeq<T>();
+        }
+
         public object Visit<T>(ZenListAddFrontExpr<T> expression, ExpressionEvaluatorEnvironment parameter)
         {
-            var e1 = (ImmutableList<T>)Evaluate(expression.Expr, parameter);
+            var e1 = (FSeq<T>)Evaluate(expression.Expr, parameter);
             var e2 = (T)Evaluate(expression.Element, parameter);
-            return e1.Insert(0, e2);
+            return e1.AddFront(e2);
         }
 
         public object Visit<T, TResult>(ZenListCaseExpr<T, TResult> expression, ExpressionEvaluatorEnvironment parameter)
         {
-            var e = (ImmutableList<T>)Evaluate(expression.ListExpr, parameter);
+            var e = (FSeq<T>)Evaluate(expression.ListExpr, parameter);
 
-            if (e.Count == 0)
+            if (e.Count() == 0)
             {
                 return Evaluate(expression.EmptyCase, parameter);
             }

--- a/ZenLib/Interpretation/ExpressionEvaluator.cs
+++ b/ZenLib/Interpretation/ExpressionEvaluator.cs
@@ -236,15 +236,7 @@ namespace ZenLib.Interpretation
         {
             var e1 = Evaluate(expression.Expr1, parameter);
             var e2 = Evaluate(expression.Expr2, parameter);
-
-            if (ReflectionUtilities.IsIDictType(typeof(T)))
-            {
-                return CommonUtilities.DictionaryEquals((dynamic)e1, (dynamic)e2);
-            }
-            else
-            {
-                return ((T)e1).Equals((T)e2);
-            }
+            return ((T)e1).Equals((T)e2);
         }
 
         public object Visit<T>(ZenIntegerComparisonExpr<T> expression, ExpressionEvaluatorEnvironment parameter)
@@ -340,35 +332,35 @@ namespace ZenLib.Interpretation
 
         public object Visit<TKey, TValue>(ZenDictEmptyExpr<TKey, TValue> expression, ExpressionEvaluatorEnvironment parameter)
         {
-            return ImmutableDictionary<TKey, TValue>.Empty;
+            return new Map<TKey, TValue>();
         }
 
         public object Visit<TKey, TValue>(ZenDictSetExpr<TKey, TValue> expression, ExpressionEvaluatorEnvironment parameter)
         {
-            var e1 = (ImmutableDictionary<TKey, TValue>)Evaluate(expression.DictExpr, parameter);
+            var e1 = (Map<TKey, TValue>)Evaluate(expression.DictExpr, parameter);
             var e2 = (TKey)Evaluate(expression.KeyExpr, parameter);
             var e3 = (TValue)Evaluate(expression.ValueExpr, parameter);
-            return e1.SetItem(e2, e3);
+            return e1.Set(e2, e3);
         }
 
         public object Visit<TKey, TValue>(ZenDictDeleteExpr<TKey, TValue> expression, ExpressionEvaluatorEnvironment parameter)
         {
-            var e1 = (ImmutableDictionary<TKey, TValue>)Evaluate(expression.DictExpr, parameter);
+            var e1 = (Map<TKey, TValue>)Evaluate(expression.DictExpr, parameter);
             var e2 = (TKey)Evaluate(expression.KeyExpr, parameter);
-            return e1.Remove(e2);
+            return e1.Delete(e2);
         }
 
         public object Visit<TKey, TValue>(ZenDictGetExpr<TKey, TValue> expression, ExpressionEvaluatorEnvironment parameter)
         {
-            var e1 = (ImmutableDictionary<TKey, TValue>)Evaluate(expression.DictExpr, parameter);
+            var e1 = (Map<TKey, TValue>)Evaluate(expression.DictExpr, parameter);
             var e2 = (TKey)Evaluate(expression.KeyExpr, parameter);
-            return CommonUtilities.DictionaryGet(e1, e2);
+            return e1.Get(e2);
         }
 
         public object Visit<TKey>(ZenDictCombineExpr<TKey> expression, ExpressionEvaluatorEnvironment parameter)
         {
-            var e1 = (ImmutableDictionary<TKey, SetUnit>)Evaluate(expression.DictExpr1, parameter);
-            var e2 = (ImmutableDictionary<TKey, SetUnit>)Evaluate(expression.DictExpr2, parameter);
+            var e1 = (Map<TKey, SetUnit>)Evaluate(expression.DictExpr1, parameter);
+            var e2 = (Map<TKey, SetUnit>)Evaluate(expression.DictExpr2, parameter);
 
             switch (expression.CombinationType)
             {

--- a/ZenLib/ModelChecking/SymbolicEvaluationVisitor.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluationVisitor.cs
@@ -113,7 +113,7 @@ namespace ZenLib.ModelChecking
                 this.ArbitraryVariables[expression] = variable;
                 return new SymbolicInteger<TModel, TVar, TBool, TBitvec, TInt, TSeq, TArray>(this.Solver, expr);
             }
-            else if (ReflectionUtilities.IsIDictType(type))
+            else if (ReflectionUtilities.IsMapType(type))
             {
                 var (variable, expr) = this.Solver.CreateDictVar(expression);
                 this.Variables.Add(variable);

--- a/ZenLib/ModelChecking/SymbolicEvaluationVisitor.cs
+++ b/ZenLib/ModelChecking/SymbolicEvaluationVisitor.cs
@@ -425,7 +425,7 @@ namespace ZenLib.ModelChecking
                 else
                 {
                     // split the symbolic list
-                    var (hd, tl) = CommonUtilities.SplitHead(values);
+                    var (hd, tl) = CommonUtilities.SplitHeadHelper(values);
                     var tlImmutable = (ImmutableList<SymbolicValue<TModel, TVar, TBool, TBitvec, TInt, TSeq, TArray>>)tl;
 
                     // push the guard into the tail of the list
@@ -436,7 +436,7 @@ namespace ZenLib.ModelChecking
 
                     // execute the cons case with placeholder values to get a new Zen value.
                     var arg1 = new ZenArgumentExpr<TList>();
-                    var arg2 = new ZenArgumentExpr<IList<TList>>();
+                    var arg2 = new ZenArgumentExpr<FSeq<TList>>();
                     var args = parameter.ArgumentsToValue.Add(arg1.ArgumentId, hd).Add(arg2.ArgumentId, rest);
                     var newEnv = new SymbolicEvaluationEnvironment<TModel, TVar, TBool, TBitvec, TInt, TSeq, TArray>(parameter.ArgumentsToExpr, args);
                     var newExpression = expression.ConsCase(arg1, arg2);

--- a/ZenLib/Solver/SolverDD.cs
+++ b/ZenLib/Solver/SolverDD.cs
@@ -612,43 +612,43 @@ namespace ZenLib.Solver
         [ExcludeFromCodeCoverage]
         public Unit DictEmpty(Type keyType, Type valueType)
         {
-            throw new ZenException("Decision diagram backend does not support IDictionary operations. Use Z3 backend.");
+            throw new ZenException("Decision diagram backend does not support Map operations. Use Z3 backend.");
         }
 
         [ExcludeFromCodeCoverage]
         public Unit DictSet(Unit arrayExpr, SymbolicValue<Assignment<T>, Variable<T>, DD, BitVector<T>, Unit, Unit, Unit> keyExpr, SymbolicValue<Assignment<T>, Variable<T>, DD, BitVector<T>, Unit, Unit, Unit> valueExpr, Type keyType, Type valueType)
         {
-            throw new ZenException("Decision diagram backend does not support IDictionary operations. Use Z3 backend.");
+            throw new ZenException("Decision diagram backend does not support Map operations. Use Z3 backend.");
         }
 
         [ExcludeFromCodeCoverage]
         public Unit DictDelete(Unit arrayExpr, SymbolicValue<Assignment<T>, Variable<T>, DD, BitVector<T>, Unit, Unit, Unit> keyExpr, Type keyType, Type valueType)
         {
-            throw new ZenException("Decision diagram backend does not support IDictionary operations. Use Z3 backend.");
+            throw new ZenException("Decision diagram backend does not support Map operations. Use Z3 backend.");
         }
 
         [ExcludeFromCodeCoverage]
         public (DD, object) DictGet(Unit arrayExpr, SymbolicValue<Assignment<T>, Variable<T>, DD, BitVector<T>, Unit, Unit, Unit> keyExpr, Type keyType, Type valueType)
         {
-            throw new ZenException("Decision diagram backend does not support IDictionary operations. Use Z3 backend.");
+            throw new ZenException("Decision diagram backend does not support Map operations. Use Z3 backend.");
         }
 
         [ExcludeFromCodeCoverage]
         public SymbolicValue<Assignment<T>, Variable<T>, DD, BitVector<T>, Unit, Unit, Unit> ConvertExprToSymbolicValue(object e, Type type)
         {
-            throw new ZenException("Decision diagram backend does not support IDictionary operations. Use Z3 backend.");
+            throw new ZenException("Decision diagram backend does not support Map operations. Use Z3 backend.");
         }
 
         [ExcludeFromCodeCoverage]
         public Unit DictUnion(Unit arrayExpr1, Unit arrayExpr2)
         {
-            throw new ZenException("Decision diagram backend does not support IDictionary operations. Use Z3 backend.");
+            throw new ZenException("Decision diagram backend does not support Map operations. Use Z3 backend.");
         }
 
         [ExcludeFromCodeCoverage]
         public Unit DictIntersect(Unit arrayExpr1, Unit arrayExpr2)
         {
-            throw new ZenException("Decision diagram backend does not support IDictionary operations. Use Z3 backend.");
+            throw new ZenException("Decision diagram backend does not support Map operations. Use Z3 backend.");
         }
 
         [ExcludeFromCodeCoverage]

--- a/ZenLib/Solver/Z3ExprToObjectConverter.cs
+++ b/ZenLib/Solver/Z3ExprToObjectConverter.cs
@@ -49,7 +49,7 @@ namespace ZenLib.Solver
             return byte.Parse(parameter.ToString());
         }
 
-        public object VisitDictionary(Type dictionaryType, Type keyType, Type valueType, Expr parameter)
+        public object VisitMap(Type dictionaryType, Type keyType, Type valueType, Expr parameter)
         {
             if (parameter.IsConstantArray)
             {
@@ -103,8 +103,8 @@ namespace ZenLib.Solver
 
         private object CreateEmptyDictionary(Type keyType, Type valueType)
         {
-            var m = typeof(ImmutableDictionary).GetMethod("Create", new Type[] { }).MakeGenericMethod(keyType, valueType);
-            return m.Invoke(null, CommonUtilities.EmptyArray);
+            var c = typeof(Map<,>).MakeGenericType(keyType, valueType).GetConstructor(new Type[] { });
+            return c.Invoke(CommonUtilities.EmptyArray);
         }
 
         private object AddKeyValuePair(object dict, object key, object value, Type keyType, Type valueType, Expr valueExpr)
@@ -121,7 +121,7 @@ namespace ZenLib.Solver
                 return m.Invoke(dict, new object[] { key, value });
             } */
 
-            var m = typeof(ImmutableDictionary<,>).MakeGenericType(keyType, valueType).GetMethod("SetItem", new Type[] { keyType, valueType });
+            var m = typeof(Map<,>).MakeGenericType(keyType, valueType).GetMethod("Set", new Type[] { keyType, valueType });
             return m.Invoke(dict, new object[] { key, value });
         }
 

--- a/ZenLib/Solver/Z3ExprToSymbolicValueConverter.cs
+++ b/ZenLib/Solver/Z3ExprToSymbolicValueConverter.cs
@@ -45,7 +45,7 @@ namespace ZenLib.Solver
             return new SymbolicBitvec<Model, Expr, BoolExpr, BitVecExpr, IntExpr, SeqExpr, ArrayExpr>(this.solver, (BitVecExpr)parameter);
         }
 
-        public SymbolicValue<Model, Expr, BoolExpr, BitVecExpr, IntExpr, SeqExpr, ArrayExpr> VisitDictionary(Type dictionaryType, Type keyType, Type valueType, Expr parameter)
+        public SymbolicValue<Model, Expr, BoolExpr, BitVecExpr, IntExpr, SeqExpr, ArrayExpr> VisitMap(Type dictionaryType, Type keyType, Type valueType, Expr parameter)
         {
             return new SymbolicDict<Model, Expr, BoolExpr, BitVecExpr, IntExpr, SeqExpr, ArrayExpr>(this.solver, (ArrayExpr)parameter);
         }

--- a/ZenLib/Solver/Z3TypeToSortConverter.cs
+++ b/ZenLib/Solver/Z3TypeToSortConverter.cs
@@ -64,7 +64,7 @@ namespace ZenLib.Solver
             return this.solver.ByteSort;
         }
 
-        public Sort VisitDictionary(Type dictionaryType, Type keyType, Type valueType, Unit parameter)
+        public Sort VisitMap(Type dictionaryType, Type keyType, Type valueType, Unit parameter)
         {
             var keySort = this.GetSortForType(keyType);
             var valueSort = this.GetSortForType(valueType);

--- a/ZenLib/ZenDataTypes/FBag.cs
+++ b/ZenLib/ZenDataTypes/FBag.cs
@@ -4,6 +4,7 @@
 
 namespace ZenLib
 {
+    using System.Collections.Immutable;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using static ZenLib.Zen;
@@ -51,7 +52,7 @@ namespace ZenLib
         /// <param name="values">The items to add to the bag.</param>
         public static FBag<T> FromArray<T>(params T[] values)
         {
-            return new FBag<T> { Values = new FSeq<Option<T>> { Values = values.Select(Option.Some).ToList() } };
+            return new FBag<T> { Values = new FSeq<Option<T>> { Values = ImmutableList.CreateRange(values.Select(Option.Some)) } };
         }
 
         /// <summary>

--- a/ZenLib/ZenDataTypes/FSeq.cs
+++ b/ZenLib/ZenDataTypes/FSeq.cs
@@ -19,7 +19,7 @@ namespace ZenLib
         /// <summary>
         /// Gets the underlying values with more recent values at the front.
         /// </summary>
-        public IList<T> Values { get; set; } = ImmutableList<T>.Empty;
+        public ImmutableList<T> Values { get; set; } = ImmutableList<T>.Empty;
 
         /// <summary>
         /// Creates a new instance of the <see cref="FSeq{T}"/> class.
@@ -32,6 +32,24 @@ namespace ZenLib
         internal FSeq(ImmutableList<T> list)
         {
             this.Values = list;
+        }
+
+        /// <summary>
+        /// Checks if the sequence is empty.
+        /// </summary>
+        /// <returns>True if the sequence contains no elements..</returns>
+        public bool IsEmpty()
+        {
+            return this.Values.Count == 0;
+        }
+
+        /// <summary>
+        /// Gets the count of elements in the sequence.
+        /// </summary>
+        /// <returns>An integer count.</returns>
+        public int Count()
+        {
+            return this.Values.Count;
         }
 
         /// <summary>
@@ -64,9 +82,9 @@ namespace ZenLib
         /// Convert a collection of items to a sequence.
         /// </summary>
         /// <param name="values">The items to add to the sequence.</param>
-        public static FSeq<T> FromArray<T>(params T[] values)
+        public static FSeq<T> FromRange<T>(IEnumerable<T> values)
         {
-            return new FSeq<T> { Values = values.ToList() };
+            return new FSeq<T> { Values = ImmutableList.CreateRange(values) };
         }
 
         /// <summary>
@@ -75,17 +93,7 @@ namespace ZenLib
         /// <returns>Zen value.</returns>
         public static Zen<FSeq<T>> Empty<T>()
         {
-            return Zen.Create<FSeq<T>>(("Values", ZenListEmptyExpr<T>.Instance));
-        }
-
-        /// <summary>
-        /// The Zen value for a sequence from a list.
-        /// </summary>
-        /// <param name="listExpr">The list expr.</param>
-        /// <returns>Zen value.</returns>
-        internal static Zen<FSeq<T>> Create<T>(Zen<IList<T>> listExpr)
-        {
-            return Zen.Create<FSeq<T>>(("Values", listExpr));
+            return ZenListEmptyExpr<T>.Instance;
         }
 
         /// <summary>
@@ -109,19 +117,7 @@ namespace ZenLib
         {
             CommonUtilities.ValidateNotNull(elements);
 
-            return FSeq.Create(Zen.List(elements.ToArray()));
-        }
-
-        /// <summary>
-        /// The Zen expression for whether an option has a value.
-        /// </summary>
-        /// <param name="expr">The expression.</param>
-        /// <returns>Zen value.</returns>
-        internal static Zen<IList<T>> Values<T>(this Zen<FSeq<T>> expr)
-        {
-            CommonUtilities.ValidateNotNull(expr);
-
-            return expr.GetField<FSeq<T>, IList<T>>("Values");
+            return Zen.List(elements.ToArray());
         }
 
         /// <summary>
@@ -151,7 +147,7 @@ namespace ZenLib
             CommonUtilities.ValidateNotNull(seqExpr);
             CommonUtilities.ValidateNotNull(valueExpr);
 
-            return FSeq.Create(ZenListAddFrontExpr<T>.Create(seqExpr.Values(), valueExpr));
+            return ZenListAddFrontExpr<T>.Create(seqExpr, valueExpr);
         }
 
         /// <summary>
@@ -170,7 +166,7 @@ namespace ZenLib
             CommonUtilities.ValidateNotNull(empty);
             CommonUtilities.ValidateNotNull(cons);
 
-            return ZenListCaseExpr<T, TResult>.Create(seqExpr.Values(), empty, (hd, tl) => cons(hd, FSeq.Create(tl)));
+            return ZenListCaseExpr<T, TResult>.Create(seqExpr, empty, (hd, tl) => cons(hd, tl));
         }
 
         /// <summary>

--- a/ZenLib/ZenDataTypes/Map.cs
+++ b/ZenLib/ZenDataTypes/Map.cs
@@ -77,7 +77,12 @@ namespace ZenLib
         /// <returns></returns>
         public Option<TValue> Get(TKey key)
         {
-            return CommonUtilities.DictionaryGet(this.Values, key);
+            if (this.Values.TryGetValue(key, out var value))
+            {
+                return Option.Some(value);
+            }
+
+            return Option.None<TValue>();
         }
 
         /// <summary>
@@ -162,7 +167,7 @@ namespace ZenLib
         /// <returns>Zen value.</returns>
         public static Zen<Map<TKey, TValue>> Empty<TKey, TValue>()
         {
-            return Create<Map<TKey, TValue>>(("Values", EmptyDict<TKey, TValue>()));
+            return EmptyDict<TKey, TValue>();
         }
     }
 
@@ -171,16 +176,6 @@ namespace ZenLib
     /// </summary>
     public static class MapExtensions
     {
-        /// <summary>
-        /// The underlying IDictionary.
-        /// </summary>
-        /// <param name="mapExpr">The map expr.</param>
-        /// <returns>Zen value.</returns>
-        internal static Zen<IDictionary<TKey, TValue>> Values<TKey, TValue>(this Zen<Map<TKey, TValue>> mapExpr)
-        {
-            return mapExpr.GetField<Map<TKey, TValue>, IDictionary<TKey, TValue>>("Values");
-        }
-
         /// <summary>
         /// Add a value to a Zen map.
         /// </summary>
@@ -194,7 +189,7 @@ namespace ZenLib
             CommonUtilities.ValidateNotNull(keyExpr);
             CommonUtilities.ValidateNotNull(valueExpr);
 
-            return Create<Map<TKey, TValue>>(("Values", DictSet(mapExpr, keyExpr, valueExpr)));
+            return DictSet(mapExpr, keyExpr, valueExpr);
         }
 
         /// <summary>
@@ -208,7 +203,7 @@ namespace ZenLib
             CommonUtilities.ValidateNotNull(mapExpr);
             CommonUtilities.ValidateNotNull(keyExpr);
 
-            return Create<Map<TKey, TValue>>(("Values", DictDelete(mapExpr, keyExpr)));
+            return DictDelete(mapExpr, keyExpr);
         }
 
         /// <summary>

--- a/ZenLib/ZenDataTypes/Map.cs
+++ b/ZenLib/ZenDataTypes/Map.cs
@@ -194,7 +194,7 @@ namespace ZenLib
             CommonUtilities.ValidateNotNull(keyExpr);
             CommonUtilities.ValidateNotNull(valueExpr);
 
-            return Create<Map<TKey, TValue>>(("Values", DictSet(mapExpr.Values(), keyExpr, valueExpr)));
+            return Create<Map<TKey, TValue>>(("Values", DictSet(mapExpr, keyExpr, valueExpr)));
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace ZenLib
             CommonUtilities.ValidateNotNull(mapExpr);
             CommonUtilities.ValidateNotNull(keyExpr);
 
-            return Create<Map<TKey, TValue>>(("Values", DictDelete(mapExpr.Values(), keyExpr)));
+            return Create<Map<TKey, TValue>>(("Values", DictDelete(mapExpr, keyExpr)));
         }
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace ZenLib
             CommonUtilities.ValidateNotNull(mapExpr);
             CommonUtilities.ValidateNotNull(keyExpr);
 
-            return DictGet(mapExpr.Values(), keyExpr);
+            return DictGet(mapExpr, keyExpr);
         }
 
         /// <summary>

--- a/ZenLib/ZenDataTypes/Set.cs
+++ b/ZenLib/ZenDataTypes/Set.cs
@@ -241,8 +241,7 @@ namespace ZenLib
             CommonUtilities.ValidateNotNull(setExpr1);
             CommonUtilities.ValidateNotNull(setExpr2);
 
-            var map = Create<Map<T, SetUnit>>(("Values", Zen.Union(setExpr1.Values(), setExpr2.Values())));
-            return Create<Set<T>>(("Values", map));
+            return Create<Set<T>>(("Values", Zen.Union(setExpr1.Values(), setExpr2.Values())));
         }
 
         /// <summary>
@@ -256,8 +255,7 @@ namespace ZenLib
             CommonUtilities.ValidateNotNull(setExpr1);
             CommonUtilities.ValidateNotNull(setExpr2);
 
-            var map = Create<Map<T, SetUnit>>(("Values", Zen.Intersect(setExpr1.Values(), setExpr2.Values())));
-            return Create<Set<T>>(("Values", map));
+            return Create<Set<T>>(("Values", Zen.Intersect(setExpr1.Values(), setExpr2.Values())));
         }
 
         /// <summary>

--- a/ZenLib/ZenDataTypes/Set.cs
+++ b/ZenLib/ZenDataTypes/Set.cs
@@ -72,7 +72,7 @@ namespace ZenLib
         /// <returns>The union of the two sets.</returns>
         public Set<T> Union(Set<T> other)
         {
-            return new Set<T>(new Map<T, SetUnit>(CommonUtilities.DictionaryUnion(this.Values.Values, other.Values.Values)));
+            return new Set<T>(CommonUtilities.DictionaryUnion(this.Values, other.Values));
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace ZenLib
         /// <returns>The intersection of the two sets.</returns>
         public Set<T> Intersect(Set<T> other)
         {
-            return new Set<T>(new Map<T, SetUnit>(CommonUtilities.DictionaryIntersect(this.Values.Values, other.Values.Values)));
+            return new Set<T>(CommonUtilities.DictionaryIntersect(this.Values, other.Values));
         }
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace ZenLib
             CommonUtilities.ValidateNotNull(setExpr1);
             CommonUtilities.ValidateNotNull(setExpr2);
 
-            var map = Create<Map<T, SetUnit>>(("Values", Zen.Union(setExpr1.Values().Values(), setExpr2.Values().Values())));
+            var map = Create<Map<T, SetUnit>>(("Values", Zen.Union(setExpr1.Values(), setExpr2.Values())));
             return Create<Set<T>>(("Values", map));
         }
 
@@ -256,7 +256,7 @@ namespace ZenLib
             CommonUtilities.ValidateNotNull(setExpr1);
             CommonUtilities.ValidateNotNull(setExpr2);
 
-            var map = Create<Map<T, SetUnit>>(("Values", Zen.Intersect(setExpr1.Values().Values(), setExpr2.Values().Values())));
+            var map = Create<Map<T, SetUnit>>(("Values", Zen.Intersect(setExpr1.Values(), setExpr2.Values())));
             return Create<Set<T>>(("Values", map));
         }
 

--- a/ZenLib/ZenLanguage/Zen.cs
+++ b/ZenLib/ZenLanguage/Zen.cs
@@ -510,7 +510,7 @@ namespace ZenLib
             return EqHelper<T>(expr1, expr2);
         }
 
-        private static Zen<bool> EqLists<T>(Zen<IList<T>> expr1, Zen<IList<T>> expr2)
+        private static Zen<bool> EqLists<T>(Zen<FSeq<T>> expr1, Zen<FSeq<T>> expr2)
         {
             return ZenListCaseExpr<T, bool>.Create(
                 expr1,
@@ -531,7 +531,7 @@ namespace ZenLib
                 return ZenEqualityExpr<T>.Create((dynamic)expr1, (dynamic)expr2);
             }
 
-            if (ReflectionUtilities.IsIListType(type))
+            if (ReflectionUtilities.IsFSeqType(type))
             {
                 var innerType = type.GetGenericArgumentsCached()[0];
                 var method = eqListsMethod.MakeGenericMethod(innerType);
@@ -1227,7 +1227,7 @@ namespace ZenLib
         /// The Zen value for an empty List.
         /// </summary>
         /// <returns>Zen value.</returns>
-        internal static Zen<IList<T>> EmptyList<T>()
+        internal static Zen<FSeq<T>> EmptyList<T>()
         {
             return ZenListEmptyExpr<T>.Instance;
         }
@@ -1320,13 +1320,13 @@ namespace ZenLib
         /// </summary>
         /// <param name="elements">Zen elements.</param>
         /// <returns>Zen value.</returns>
-        internal static Zen<IList<T>> List<T>(params Zen<T>[] elements)
+        internal static Zen<FSeq<T>> List<T>(params Zen<T>[] elements)
         {
             CommonUtilities.ValidateNotNull(elements);
 
             Zen<T>[] copy = new Zen<T>[elements.Length];
-            System.Array.Copy(elements, copy, elements.Length);
-            System.Array.Reverse(copy);
+            Array.Copy(elements, copy, elements.Length);
+            Array.Reverse(copy);
             var list = EmptyList<T>();
             foreach (var element in copy)
             {

--- a/ZenLib/ZenLanguage/Zen.cs
+++ b/ZenLib/ZenLanguage/Zen.cs
@@ -525,7 +525,7 @@ namespace ZenLib
             if (type == ReflectionUtilities.BoolType ||
                 type == ReflectionUtilities.StringType ||
                 ReflectionUtilities.IsIntegerType(type) ||
-                ReflectionUtilities.IsIDictType(type) ||
+                ReflectionUtilities.IsMapType(type) ||
                 ReflectionUtilities.IsSeqType(type))
             {
                 return ZenEqualityExpr<T>.Create((dynamic)expr1, (dynamic)expr2);
@@ -1236,7 +1236,7 @@ namespace ZenLib
         /// The Zen value for an empty dictionary.
         /// </summary>
         /// <returns>Zen value.</returns>
-        internal static Zen<IDictionary<TKey, TValue>> EmptyDict<TKey, TValue>()
+        internal static Zen<Map<TKey, TValue>> EmptyDict<TKey, TValue>()
         {
             return ZenDictEmptyExpr<TKey, TValue>.Instance;
         }
@@ -1245,9 +1245,9 @@ namespace ZenLib
         /// The union of two zen dictionaries.
         /// </summary>
         /// <returns>Zen value.</returns>
-        internal static Zen<IDictionary<TKey, SetUnit>> Union<TKey>(
-            Zen<IDictionary<TKey, SetUnit>> d1,
-            Zen<IDictionary<TKey, SetUnit>> d2)
+        internal static Zen<Map<TKey, SetUnit>> Union<TKey>(
+            Zen<Map<TKey, SetUnit>> d1,
+            Zen<Map<TKey, SetUnit>> d2)
         {
             return ZenDictCombineExpr<TKey>.Create(d1, d2, ZenDictCombineExpr<TKey>.CombineType.Union);
         }
@@ -1256,9 +1256,9 @@ namespace ZenLib
         /// The intersection of two zen dictionaries.
         /// </summary>
         /// <returns>Zen value.</returns>
-        internal static Zen<IDictionary<TKey, SetUnit>> Intersect<TKey>(
-            Zen<IDictionary<TKey, SetUnit>> d1,
-            Zen<IDictionary<TKey, SetUnit>> d2)
+        internal static Zen<Map<TKey, SetUnit>> Intersect<TKey>(
+            Zen<Map<TKey, SetUnit>> d1,
+            Zen<Map<TKey, SetUnit>> d2)
         {
             return ZenDictCombineExpr<TKey>.Create(d1, d2, ZenDictCombineExpr<TKey>.CombineType.Intersect);
         }
@@ -1267,9 +1267,9 @@ namespace ZenLib
         /// The Zen value for an empty dict.
         /// </summary>
         /// <returns>Zen value.</returns>
-        internal static Zen<IDictionary<TKey, TValue>> ArbitraryDict<TKey, TValue>()
+        internal static Zen<Map<TKey, TValue>> ArbitraryDict<TKey, TValue>()
         {
-            return new ZenArbitraryExpr<IDictionary<TKey, TValue>>();
+            return new ZenArbitraryExpr<Map<TKey, TValue>>();
         }
 
         /// <summary>
@@ -1288,7 +1288,7 @@ namespace ZenLib
         /// <param name="keyExpr">The key expression.</param>
         /// <param name="valueExpr">The value expression.</param>
         /// <returns>Zen value.</returns>
-        internal static Zen<IDictionary<TKey, TValue>> DictSet<TKey, TValue>(Zen<IDictionary<TKey, TValue>> dictExpr, Zen<TKey> keyExpr, Zen<TValue> valueExpr)
+        internal static Zen<Map<TKey, TValue>> DictSet<TKey, TValue>(Zen<Map<TKey, TValue>> dictExpr, Zen<TKey> keyExpr, Zen<TValue> valueExpr)
         {
             return ZenDictSetExpr<TKey, TValue>.Create(dictExpr, keyExpr, valueExpr);
         }
@@ -1299,7 +1299,7 @@ namespace ZenLib
         /// <param name="dictExpr">The dictionary expression.</param>
         /// <param name="keyExpr">The key expression.</param>
         /// <returns>Zen value.</returns>
-        internal static Zen<IDictionary<TKey, TValue>> DictDelete<TKey, TValue>(Zen<IDictionary<TKey, TValue>> dictExpr, Zen<TKey> keyExpr)
+        internal static Zen<Map<TKey, TValue>> DictDelete<TKey, TValue>(Zen<Map<TKey, TValue>> dictExpr, Zen<TKey> keyExpr)
         {
             return ZenDictDeleteExpr<TKey, TValue>.Create(dictExpr, keyExpr);
         }
@@ -1310,7 +1310,7 @@ namespace ZenLib
         /// <param name="dictExpr">The dictionary expression.</param>
         /// <param name="keyExpr">The key expression.</param>
         /// <returns>Zen value.</returns>
-        internal static Zen<Option<TValue>> DictGet<TKey, TValue>(Zen<IDictionary<TKey, TValue>> dictExpr, Zen<TKey> keyExpr)
+        internal static Zen<Option<TValue>> DictGet<TKey, TValue>(Zen<Map<TKey, TValue>> dictExpr, Zen<TKey> keyExpr)
         {
             return ZenDictGetExpr<TKey, TValue>.Create(dictExpr, keyExpr);
         }

--- a/ZenLib/ZenLanguage/ZenDictCombineExpr.cs
+++ b/ZenLib/ZenLanguage/ZenDictCombineExpr.cs
@@ -11,25 +11,25 @@ namespace ZenLib
     /// <summary>
     /// Class representing a dictionary union expression.
     /// </summary>
-    internal sealed class ZenDictCombineExpr<TKey> : Zen<IDictionary<TKey, SetUnit>>
+    internal sealed class ZenDictCombineExpr<TKey> : Zen<Map<TKey, SetUnit>>
     {
         /// <summary>
         /// Static creation function for hash consing.
         /// </summary>
-        private static Func<(Zen<IDictionary<TKey, SetUnit>>, Zen<IDictionary<TKey, SetUnit>>, CombineType), Zen<IDictionary<TKey, SetUnit>>> createFunc = (v) =>
+        private static Func<(Zen<Map<TKey, SetUnit>>, Zen<Map<TKey, SetUnit>>, CombineType), Zen<Map<TKey, SetUnit>>> createFunc = (v) =>
             Simplify(v.Item1, v.Item2, v.Item3);
 
         /// <summary>
         /// Hash cons table for ZenDictUnionExpr.
         /// </summary>
-        private static HashConsTable<(long, long, int), Zen<IDictionary<TKey, SetUnit>>> hashConsTable =
-            new HashConsTable<(long, long, int), Zen<IDictionary<TKey, SetUnit>>>();
+        private static HashConsTable<(long, long, int), Zen<Map<TKey, SetUnit>>> hashConsTable =
+            new HashConsTable<(long, long, int), Zen<Map<TKey, SetUnit>>>();
 
         /// <summary>
         /// Unroll a ZenDictUnionExpr.
         /// </summary>
         /// <returns>The unrolled expr.</returns>
-        public override Zen<IDictionary<TKey, SetUnit>> Unroll()
+        public override Zen<Map<TKey, SetUnit>> Unroll()
         {
             return Create(this.DictExpr1.Unroll(), this.DictExpr2.Unroll(), this.CombinationType);
         }
@@ -41,9 +41,9 @@ namespace ZenLib
         /// <param name="dict2">The dictionary expr.</param>
         /// <param name="combinationType">The combination type.</param>
         /// <returns>The new Zen expr.</returns>
-        private static Zen<IDictionary<TKey, SetUnit>> Simplify(
-            Zen<IDictionary<TKey, SetUnit>> dict1,
-            Zen<IDictionary<TKey, SetUnit>> dict2,
+        private static Zen<Map<TKey, SetUnit>> Simplify(
+            Zen<Map<TKey, SetUnit>> dict1,
+            Zen<Map<TKey, SetUnit>> dict2,
             CombineType combinationType)
         {
             if (dict1 is ZenDictCombineExpr<TKey> e1 &&
@@ -70,9 +70,9 @@ namespace ZenLib
         /// <param name="dictExpr2">The second dictionary expr.</param>
         /// <param name="combineType">The combination type.</param>
         /// <returns>The new expr.</returns>
-        public static Zen<IDictionary<TKey, SetUnit>> Create(
-            Zen<IDictionary<TKey, SetUnit>> dictExpr1,
-            Zen<IDictionary<TKey, SetUnit>> dictExpr2,
+        public static Zen<Map<TKey, SetUnit>> Create(
+            Zen<Map<TKey, SetUnit>> dictExpr1,
+            Zen<Map<TKey, SetUnit>> dictExpr2,
             CombineType combineType)
         {
             CommonUtilities.ValidateNotNull(dictExpr1);
@@ -90,8 +90,8 @@ namespace ZenLib
         /// <param name="dictExpr2">The second dictionary expression.</param>
         /// <param name="combineType">The combination type.</param>
         private ZenDictCombineExpr(
-            Zen<IDictionary<TKey, SetUnit>> dictExpr1,
-            Zen<IDictionary<TKey, SetUnit>> dictExpr2,
+            Zen<Map<TKey, SetUnit>> dictExpr1,
+            Zen<Map<TKey, SetUnit>> dictExpr2,
             CombineType combineType)
         {
             this.DictExpr1 = dictExpr1;
@@ -102,12 +102,12 @@ namespace ZenLib
         /// <summary>
         /// Gets the first dictionary expr.
         /// </summary>
-        public Zen<IDictionary<TKey, SetUnit>> DictExpr1 { get; }
+        public Zen<Map<TKey, SetUnit>> DictExpr1 { get; }
 
         /// <summary>
         /// Gets the second dictionary expr.
         /// </summary>
-        public Zen<IDictionary<TKey, SetUnit>> DictExpr2 { get; }
+        public Zen<Map<TKey, SetUnit>> DictExpr2 { get; }
 
         /// <summary>
         /// Gets the combination type.

--- a/ZenLib/ZenLanguage/ZenDictDeleteExpr.cs
+++ b/ZenLib/ZenLanguage/ZenDictDeleteExpr.cs
@@ -11,12 +11,12 @@ namespace ZenLib
     /// <summary>
     /// Class representing a dictionary delete expression.
     /// </summary>
-    internal sealed class ZenDictDeleteExpr<TKey, TValue> : Zen<IDictionary<TKey, TValue>>
+    internal sealed class ZenDictDeleteExpr<TKey, TValue> : Zen<Map<TKey, TValue>>
     {
         /// <summary>
         /// Static creation function for hash consing.
         /// </summary>
-        private static Func<(Zen<IDictionary<TKey, TValue>>, Zen<TKey>), ZenDictDeleteExpr<TKey, TValue>> createFunc = (v) =>
+        private static Func<(Zen<Map<TKey, TValue>>, Zen<TKey>), ZenDictDeleteExpr<TKey, TValue>> createFunc = (v) =>
             new ZenDictDeleteExpr<TKey, TValue>(v.Item1, v.Item2);
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace ZenLib
         /// Unroll a ZenDictDeleteExpr.
         /// </summary>
         /// <returns>The unrolled expr.</returns>
-        public override Zen<IDictionary<TKey, TValue>> Unroll()
+        public override Zen<Map<TKey, TValue>> Unroll()
         {
             return Create(this.DictExpr.Unroll(), this.KeyExpr.Unroll());
         }
@@ -40,7 +40,7 @@ namespace ZenLib
         /// <param name="dictExpr">The dictionary expr.</param>
         /// <param name="key">The key expr.</param>
         /// <returns>The new expr.</returns>
-        public static ZenDictDeleteExpr<TKey, TValue> Create(Zen<IDictionary<TKey, TValue>> dictExpr, Zen<TKey> key)
+        public static ZenDictDeleteExpr<TKey, TValue> Create(Zen<Map<TKey, TValue>> dictExpr, Zen<TKey> key)
         {
             CommonUtilities.ValidateNotNull(dictExpr);
             CommonUtilities.ValidateNotNull(key);
@@ -55,7 +55,7 @@ namespace ZenLib
         /// </summary>
         /// <param name="dictExpr">The dictionary expression.</param>
         /// <param name="keyExpr">The key expression to add a value for.</param>
-        private ZenDictDeleteExpr(Zen<IDictionary<TKey, TValue>> dictExpr, Zen<TKey> keyExpr)
+        private ZenDictDeleteExpr(Zen<Map<TKey, TValue>> dictExpr, Zen<TKey> keyExpr)
         {
             this.DictExpr = dictExpr;
             this.KeyExpr = keyExpr;
@@ -64,7 +64,7 @@ namespace ZenLib
         /// <summary>
         /// Gets the dictionary expr.
         /// </summary>
-        public Zen<IDictionary<TKey, TValue>> DictExpr { get; }
+        public Zen<Map<TKey, TValue>> DictExpr { get; }
 
         /// <summary>
         /// Gets the key to add the value for.

--- a/ZenLib/ZenLanguage/ZenDictEmptyExpr.cs
+++ b/ZenLib/ZenLanguage/ZenDictEmptyExpr.cs
@@ -10,7 +10,7 @@ namespace ZenLib
     /// <summary>
     /// Class representing an empty dictionary expression.
     /// </summary>
-    internal sealed class ZenDictEmptyExpr<TKey, TValue> : Zen<IDictionary<TKey, TValue>>
+    internal sealed class ZenDictEmptyExpr<TKey, TValue> : Zen<Map<TKey, TValue>>
     {
         /// <summary>
         /// The empty dictionary instance.
@@ -21,7 +21,7 @@ namespace ZenLib
         /// Unroll the expression.
         /// </summary>
         /// <returns>The unrolled expression.</returns>
-        public override Zen<IDictionary<TKey, TValue>> Unroll()
+        public override Zen<Map<TKey, TValue>> Unroll()
         {
             return this;
         }

--- a/ZenLib/ZenLanguage/ZenDictGetExpr.cs
+++ b/ZenLib/ZenLanguage/ZenDictGetExpr.cs
@@ -16,7 +16,7 @@ namespace ZenLib
         /// <summary>
         /// Static creation function for hash consing.
         /// </summary>
-        private static Func<(Zen<IDictionary<TKey, TValue>>, Zen<TKey>), Zen<Option<TValue>>> createFunc = (v) =>
+        private static Func<(Zen<Map<TKey, TValue>>, Zen<TKey>), Zen<Option<TValue>>> createFunc = (v) =>
             Simplify(v.Item1, v.Item2);
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace ZenLib
         /// <param name="dict">The dictionary expr.</param>
         /// <param name="key">The key expr.</param>
         /// <returns>The new Zen expr.</returns>
-        private static Zen<Option<TValue>> Simplify(Zen<IDictionary<TKey, TValue>> dict, Zen<TKey> key)
+        private static Zen<Option<TValue>> Simplify(Zen<Map<TKey, TValue>> dict, Zen<TKey> key)
         {
             if (dict is ZenDictEmptyExpr<TKey, TValue>)
             {
@@ -66,7 +66,7 @@ namespace ZenLib
         /// <param name="dictExpr">The dictionary expr.</param>
         /// <param name="key">The key expr.</param>
         /// <returns>The new expr.</returns>
-        public static Zen<Option<TValue>> Create(Zen<IDictionary<TKey, TValue>> dictExpr, Zen<TKey> key)
+        public static Zen<Option<TValue>> Create(Zen<Map<TKey, TValue>> dictExpr, Zen<TKey> key)
         {
             CommonUtilities.ValidateNotNull(dictExpr);
             CommonUtilities.ValidateNotNull(key);
@@ -81,7 +81,7 @@ namespace ZenLib
         /// </summary>
         /// <param name="dictExpr">The dictionary expression.</param>
         /// <param name="keyExpr">The key expression to add a value for.</param>
-        private ZenDictGetExpr(Zen<IDictionary<TKey, TValue>> dictExpr, Zen<TKey> keyExpr)
+        private ZenDictGetExpr(Zen<Map<TKey, TValue>> dictExpr, Zen<TKey> keyExpr)
         {
             this.DictExpr = dictExpr;
             this.KeyExpr = keyExpr;
@@ -90,7 +90,7 @@ namespace ZenLib
         /// <summary>
         /// Gets the dictionary expr.
         /// </summary>
-        public Zen<IDictionary<TKey, TValue>> DictExpr { get; }
+        public Zen<Map<TKey, TValue>> DictExpr { get; }
 
         /// <summary>
         /// Gets the key to add the value for.

--- a/ZenLib/ZenLanguage/ZenDictSetExpr.cs
+++ b/ZenLib/ZenLanguage/ZenDictSetExpr.cs
@@ -11,25 +11,25 @@ namespace ZenLib
     /// <summary>
     /// Class representing a dictionary set expression.
     /// </summary>
-    internal sealed class ZenDictSetExpr<TKey, TValue> : Zen<IDictionary<TKey, TValue>>
+    internal sealed class ZenDictSetExpr<TKey, TValue> : Zen<Map<TKey, TValue>>
     {
         /// <summary>
         /// Static creation function for hash consing.
         /// </summary>
-        private static Func<(Zen<IDictionary<TKey, TValue>>, Zen<TKey>, Zen<TValue>), Zen<IDictionary<TKey, TValue>>> createFunc = (v) =>
+        private static Func<(Zen<Map<TKey, TValue>>, Zen<TKey>, Zen<TValue>), Zen<Map<TKey, TValue>>> createFunc = (v) =>
             Simplify(v.Item1, v.Item2, v.Item3);
 
         /// <summary>
         /// Hash cons table for ZenDictSetExpr.
         /// </summary>
-        private static HashConsTable<(long, long, long), Zen<IDictionary<TKey, TValue>>> hashConsTable =
-            new HashConsTable<(long, long, long), Zen<IDictionary<TKey, TValue>>>();
+        private static HashConsTable<(long, long, long), Zen<Map<TKey, TValue>>> hashConsTable =
+            new HashConsTable<(long, long, long), Zen<Map<TKey, TValue>>>();
 
         /// <summary>
         /// Unroll a ZenDictSetExpr.
         /// </summary>
         /// <returns>The unrolled expr.</returns>
-        public override Zen<IDictionary<TKey, TValue>> Unroll()
+        public override Zen<Map<TKey, TValue>> Unroll()
         {
             return Create(this.DictExpr.Unroll(), this.KeyExpr.Unroll(), this.ValueExpr.Unroll());
         }
@@ -41,7 +41,7 @@ namespace ZenLib
         /// <param name="key">The key expr.</param>
         /// <param name="value">The value expr.</param>
         /// <returns>The new Zen expr.</returns>
-        private static Zen<IDictionary<TKey, TValue>> Simplify(Zen<IDictionary<TKey, TValue>> dict, Zen<TKey> key, Zen<TValue> value)
+        private static Zen<Map<TKey, TValue>> Simplify(Zen<Map<TKey, TValue>> dict, Zen<TKey> key, Zen<TValue> value)
         {
             if (dict is ZenDictSetExpr<TKey, TValue> e1 && e1.KeyExpr.Equals(key))
             {
@@ -63,7 +63,7 @@ namespace ZenLib
         /// <param name="key">The key expr.</param>
         /// <param name="value">The value expr.</param>
         /// <returns>The new expr.</returns>
-        public static Zen<IDictionary<TKey, TValue>> Create(Zen<IDictionary<TKey, TValue>> dictExpr, Zen<TKey> key, Zen<TValue> value)
+        public static Zen<Map<TKey, TValue>> Create(Zen<Map<TKey, TValue>> dictExpr, Zen<TKey> key, Zen<TValue> value)
         {
             CommonUtilities.ValidateNotNull(dictExpr);
             CommonUtilities.ValidateNotNull(key);
@@ -80,7 +80,7 @@ namespace ZenLib
         /// <param name="dictExpr">The dictionary expression.</param>
         /// <param name="keyExpr">The key expression to add a value for.</param>
         /// <param name="valueExpr">The expression for the value.</param>
-        private ZenDictSetExpr(Zen<IDictionary<TKey, TValue>> dictExpr, Zen<TKey> keyExpr, Zen<TValue> valueExpr)
+        private ZenDictSetExpr(Zen<Map<TKey, TValue>> dictExpr, Zen<TKey> keyExpr, Zen<TValue> valueExpr)
         {
             this.DictExpr = dictExpr;
             this.KeyExpr = keyExpr;
@@ -90,7 +90,7 @@ namespace ZenLib
         /// <summary>
         /// Gets the dictionary expr.
         /// </summary>
-        public Zen<IDictionary<TKey, TValue>> DictExpr { get; }
+        public Zen<Map<TKey, TValue>> DictExpr { get; }
 
         /// <summary>
         /// Gets the key to add the value for.

--- a/ZenLib/ZenLanguage/ZenListAddFrontExpr.cs
+++ b/ZenLib/ZenLanguage/ZenListAddFrontExpr.cs
@@ -11,12 +11,12 @@ namespace ZenLib
     /// <summary>
     /// Class representing a list add expression.
     /// </summary>
-    internal sealed class ZenListAddFrontExpr<T> : Zen<IList<T>>
+    internal sealed class ZenListAddFrontExpr<T> : Zen<FSeq<T>>
     {
         /// <summary>
         /// Static creation function for hash consing.
         /// </summary>
-        private static Func<(Zen<IList<T>>, Zen<T>), ZenListAddFrontExpr<T>> createFunc = (v) => new ZenListAddFrontExpr<T>(v.Item1, v.Item2);
+        private static Func<(Zen<FSeq<T>>, Zen<T>), ZenListAddFrontExpr<T>> createFunc = (v) => new ZenListAddFrontExpr<T>(v.Item1, v.Item2);
 
         /// <summary>
         /// Hash cons table for ZenListAddFrontExpr.
@@ -27,7 +27,7 @@ namespace ZenLib
         /// Unroll a ZenListAddFrontExpr.
         /// </summary>
         /// <returns>The unrolled expr.</returns>
-        public override Zen<IList<T>> Unroll()
+        public override Zen<FSeq<T>> Unroll()
         {
             return Create(this.Expr.Unroll(), this.Element.Unroll());
         }
@@ -38,7 +38,7 @@ namespace ZenLib
         /// <param name="expr">The list expr.</param>
         /// <param name="element">The element expr.</param>
         /// <returns>The new expr.</returns>
-        public static ZenListAddFrontExpr<T> Create(Zen<IList<T>> expr, Zen<T> element)
+        public static ZenListAddFrontExpr<T> Create(Zen<FSeq<T>> expr, Zen<T> element)
         {
             CommonUtilities.ValidateNotNull(expr);
             CommonUtilities.ValidateNotNull(element);
@@ -53,7 +53,7 @@ namespace ZenLib
         /// </summary>
         /// <param name="expr">The list expression.</param>
         /// <param name="element">The expression for the element to add.</param>
-        private ZenListAddFrontExpr(Zen<IList<T>> expr, Zen<T> element)
+        private ZenListAddFrontExpr(Zen<FSeq<T>> expr, Zen<T> element)
         {
             this.Expr = expr;
             this.Element = element;
@@ -62,7 +62,7 @@ namespace ZenLib
         /// <summary>
         /// Gets the list expr.
         /// </summary>
-        public Zen<IList<T>> Expr { get; }
+        public Zen<FSeq<T>> Expr { get; }
 
         /// <summary>
         /// Gets the element to add.
@@ -76,7 +76,7 @@ namespace ZenLib
         [ExcludeFromCodeCoverage]
         public override string ToString()
         {
-            return $"({this.Element} :: {this.Expr})";
+            return $"Cons({this.Element}, {this.Expr})";
         }
 
         /// <summary>

--- a/ZenLib/ZenLanguage/ZenListCaseExpr.cs
+++ b/ZenLib/ZenLanguage/ZenListCaseExpr.cs
@@ -30,7 +30,7 @@ namespace ZenLib
         /// <param name="consCase">The cons case.</param>
         /// <param name="unroll">Whether to unroll the expr.</param>
         /// <returns></returns>
-        private static Zen<TResult> Simplify(Zen<IList<T>> e, Zen<TResult> emptyCase, Func<Zen<T>, Zen<IList<T>>, Zen<TResult>> consCase, bool unroll)
+        private static Zen<TResult> Simplify(Zen<FSeq<T>> e, Zen<TResult> emptyCase, Func<Zen<T>, Zen<FSeq<T>>, Zen<TResult>> consCase, bool unroll)
         {
             if (e is ZenListEmptyExpr<T> l1)
             {
@@ -42,7 +42,7 @@ namespace ZenLib
                 return consCase(l2.Element, l2.Expr);
             }
 
-            if (unroll && e is ZenIfExpr<IList<T>> l3)
+            if (unroll && e is ZenIfExpr<FSeq<T>> l3)
             {
                 var tbranch = Create(l3.TrueExpr, emptyCase, consCase);
                 var fbranch = Create(l3.FalseExpr, emptyCase, consCase);
@@ -61,9 +61,9 @@ namespace ZenLib
         /// <param name="unroll">Whether to unroll the expr.</param>
         /// <returns>The new expr.</returns>
         public static Zen<TResult> Create(
-            Zen<IList<T>> listExpr,
+            Zen<FSeq<T>> listExpr,
             Zen<TResult> empty,
-            Func<Zen<T>, Zen<IList<T>>, Zen<TResult>> cons,
+            Func<Zen<T>, Zen<FSeq<T>>, Zen<TResult>> cons,
             bool unroll = false)
         {
             CommonUtilities.ValidateNotNull(listExpr);
@@ -80,9 +80,9 @@ namespace ZenLib
         /// <param name="empty">The empty case.</param>
         /// <param name="cons">The cons case.</param>
         private ZenListCaseExpr(
-            Zen<IList<T>> listExpr,
+            Zen<FSeq<T>> listExpr,
             Zen<TResult> empty,
-            Func<Zen<T>, Zen<IList<T>>, Zen<TResult>> cons)
+            Func<Zen<T>, Zen<FSeq<T>>, Zen<TResult>> cons)
         {
             this.ListExpr = listExpr;
             this.EmptyCase = empty;
@@ -92,7 +92,7 @@ namespace ZenLib
         /// <summary>
         /// Gets the list expr.
         /// </summary>
-        public Zen<IList<T>> ListExpr { get; }
+        public Zen<FSeq<T>> ListExpr { get; }
 
         /// <summary>
         /// Gets the list expr.
@@ -102,7 +102,7 @@ namespace ZenLib
         /// <summary>
         /// Gets the element to add.
         /// </summary>
-        public Func<Zen<T>, Zen<IList<T>>, Zen<TResult>> ConsCase { get; }
+        public Func<Zen<T>, Zen<FSeq<T>>, Zen<TResult>> ConsCase { get; }
 
         /// <summary>
         /// Convert the expression to a string.

--- a/ZenLib/ZenLanguage/ZenListEmptyExpr.cs
+++ b/ZenLib/ZenLanguage/ZenListEmptyExpr.cs
@@ -4,13 +4,12 @@
 
 namespace ZenLib
 {
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
     /// Class representing an empty list expression.
     /// </summary>
-    internal sealed class ZenListEmptyExpr<T> : Zen<IList<T>>
+    internal sealed class ZenListEmptyExpr<T> : Zen<FSeq<T>>
     {
         /// <summary>
         /// The empty list instance.
@@ -21,7 +20,7 @@ namespace ZenLib
         /// Unroll the expression.
         /// </summary>
         /// <returns>The unrolled expression.</returns>
-        public override Zen<IList<T>> Unroll()
+        public override Zen<FSeq<T>> Unroll()
         {
             return this;
         }

--- a/ZenLibTests/AttributeTests.cs
+++ b/ZenLibTests/AttributeTests.cs
@@ -28,17 +28,17 @@ namespace ZenLib.Tests
         {
             // work around unused field warning.
             ObjectAttribute o1;
-            o1.Field1 = new List<int>();
-            o1.Field2 = new List<int>();
-            o1.Field3 = new List<int>();
+            o1.Field1 = new FSeq<int>();
+            o1.Field2 = new FSeq<int>();
+            o1.Field3 = new FSeq<int>();
 
             var o = Symbolic<ObjectAttribute>(depth: 3, exhaustiveDepth: true);
 
-            var s1 = o.GetField<ObjectAttribute, IList<int>>("Field1").ToString();
-            var s2 = o.GetField<ObjectAttribute, IList<int>>("Field2").ToString();
-            var s3 = o.GetField<ObjectAttribute, IList<int>>("Field3").ToString();
+            var s1 = o.GetField<ObjectAttribute, FSeq<int>>("Field1").ToString();
+            var s2 = o.GetField<ObjectAttribute, FSeq<int>>("Field2").ToString();
+            var s3 = o.GetField<ObjectAttribute, FSeq<int>>("Field3").ToString();
 
-            Assert.AreEqual(11, s1.Split("::").Length);
+            Assert.AreEqual(11, s1.Split("Cons").Length);
             Assert.AreEqual(6, s2.Split("Eq").Length);
             Assert.AreEqual(4, s3.Split("Eq").Length);
         }
@@ -46,13 +46,13 @@ namespace ZenLib.Tests
         private struct ObjectAttribute
         {
             [ZenSize(depth: 10, EnumerationType.FixedSize)]
-            public IList<int> Field1;
+            public FSeq<int> Field1;
 
             [ZenSize(depth: 5, EnumerationType.Exhaustive)]
-            public IList<int> Field2;
+            public FSeq<int> Field2;
 
             [ZenSize(depth: -1, EnumerationType.User)]
-            public IList<int> Field3;
+            public FSeq<int> Field3;
         }
     }
 }

--- a/ZenLibTests/ConversionTests.cs
+++ b/ZenLibTests/ConversionTests.cs
@@ -34,8 +34,8 @@ namespace ZenLib.Tests
             CheckAgreement<Option<int>>(x => x == Option.Some(3));
             CheckAgreement<Pair<int, int>>(x => x == new Pair<int, int> { Item1 = 1, Item2 = 2 });
             CheckAgreement<(int, int)>(x => x == (1, 2));
-            CheckAgreement<IList<int>>(x => x == new List<int>() { 1, 2, 3 });
-            CheckAgreement<IList<IList<int>>>(x => x == new List<IList<int>>() { new List<int>() { 1 } });
+            CheckAgreement<FSeq<int>>(x => x == FSeq.FromRange(new List<int>() { 1, 2, 3 }));
+            CheckAgreement<FSeq<FSeq<int>>>(x => x == FSeq.FromRange(new List<FSeq<int>>() { FSeq.FromRange(new List<int>() { 1 }) }));
             CheckAgreement<FString>(x => x == new FString("hello"));
             CheckAgreement<Object2>(x => x == new Object2 { Field1 = 1, Field2 = 2 });
 
@@ -66,7 +66,7 @@ namespace ZenLib.Tests
             CheckEqual(Option.Some(8));
             CheckEqual(new Pair<int, int> { Item1 = 9, Item2 = 10 });
             CheckEqual(new FString("hello"));
-            CheckEqualLists(new List<int>() { 1, 2, 3 });
+            CheckEqualLists(FSeq.FromRange(new List<int>() { 1, 2, 3 }));
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestConvertConcreteListField()
         {
-            var o = new NestedClass { Field1 = new List<int>() };
+            var o = new NestedClass { Field1 = FSeq.FromRange(new List<int>()) };
             var _ = Constant(o);
         }
 
@@ -139,7 +139,7 @@ namespace ZenLib.Tests
         [ExpectedException(typeof(ZenException))]
         public void TestConvertNullListValue()
         {
-            IList<Object1> o = new List<Object1> { { null } };
+            FSeq<Object1> o = FSeq.FromRange(new List<Object1> { { null } });
             var _ = Constant(o);
         }
 
@@ -169,16 +169,16 @@ namespace ZenLib.Tests
         /// Check we convert a list correctly.
         /// </summary>
         /// <param name="value">The value.</param>
-        private void CheckEqualLists<T>(IList<T> value)
+        private void CheckEqualLists<T>(FSeq<T> value)
         {
-            var f = new ZenFunction<IList<T>>(() => Lift(value));
+            var f = new ZenFunction<FSeq<T>>(() => Lift(value));
             var result = f.Evaluate();
 
-            Assert.AreEqual(value.Count, result.Count);
+            Assert.AreEqual(value.Count(), result.Count());
 
-            for (int i = 0; i < value.Count; i++)
+            for (int i = 0; i < value.Count(); i++)
             {
-                Assert.AreEqual(value[i], result[i]);
+                Assert.AreEqual(value.Values[i], result.Values[i]);
             }
         }
 
@@ -187,7 +187,7 @@ namespace ZenLib.Tests
         /// </summary>
         internal class NestedClass
         {
-            public IList<int> Field1 { get; set; }
+            public FSeq<int> Field1 { get; set; }
         }
     }
 }

--- a/ZenLibTests/ConversionTests.cs
+++ b/ZenLibTests/ConversionTests.cs
@@ -39,7 +39,7 @@ namespace ZenLib.Tests
             CheckAgreement<FString>(x => x == new FString("hello"));
             CheckAgreement<Object2>(x => x == new Object2 { Field1 = 1, Field2 = 2 });
 
-            CheckAgreement<IDictionary<int, int>>(x =>
+            CheckAgreement<FMap<int, int>>(x =>
             {
                 var d = new FMap<int, int>();
                 d.Set(1, 2);

--- a/ZenLibTests/DefaultValueTests.cs
+++ b/ZenLibTests/DefaultValueTests.cs
@@ -48,9 +48,9 @@ namespace ZenLib.Tests
             var l = ReflectionUtilities.GetDefaultValue<IList<int>>();
             Assert.AreEqual(0, l.Count);
 
-            var m = ReflectionUtilities.GetDefaultValue<IDictionary<byte, byte>>();
-            Assert.AreEqual(0, m.Count);
-            var v = Option.Null<IDictionary<byte, byte>>();
+            var m = ReflectionUtilities.GetDefaultValue<Map<byte, byte>>();
+            Assert.AreEqual(0, m.Count());
+            var v = Option.Null<Map<byte, byte>>();
 
             var d = ReflectionUtilities.GetDefaultValue<FMap<int, int>>();
         }

--- a/ZenLibTests/DefaultValueTests.cs
+++ b/ZenLibTests/DefaultValueTests.cs
@@ -45,8 +45,8 @@ namespace ZenLib.Tests
             Assert.AreEqual(o.Field1, 0);
             Assert.AreEqual(o.Field2, 0);
 
-            var l = ReflectionUtilities.GetDefaultValue<IList<int>>();
-            Assert.AreEqual(0, l.Count);
+            var l = ReflectionUtilities.GetDefaultValue<FSeq<int>>();
+            Assert.AreEqual(0, l.Count());
 
             var m = ReflectionUtilities.GetDefaultValue<Map<byte, byte>>();
             Assert.AreEqual(0, m.Count());

--- a/ZenLibTests/ExtensionTests.cs
+++ b/ZenLibTests/ExtensionTests.cs
@@ -5,6 +5,7 @@
 namespace ZenLib.Tests
 {
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Diagnostics.CodeAnalysis;
     using System.Numerics;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -96,21 +97,21 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestSolveLists()
         {
-            var a = Arbitrary<IList<int>>();
-            var b = Arbitrary<IList<int>>();
+            var a = Arbitrary<FSeq<int>>();
+            var b = Arbitrary<FSeq<int>>();
 
-            var expr = And(a == new List<int> { 1, 2 }, b == new List<int> { 3 });
+            var expr = And(a == FSeq.FromRange(new List<int> { 1, 2 }), b == FSeq.FromRange(new List<int> { 3 }));
             var solution = expr.Solve();
 
             var asol = solution.Get(a);
             var bsol = solution.Get(b);
 
-            Assert.AreEqual(2, asol.Count);
-            Assert.AreEqual(1, bsol.Count);
+            Assert.AreEqual(2, asol.Count());
+            Assert.AreEqual(1, bsol.Count());
 
-            Assert.AreEqual(1, asol[0]);
-            Assert.AreEqual(2, asol[1]);
-            Assert.AreEqual(3, bsol[0]);
+            Assert.AreEqual(1, asol.Values[0]);
+            Assert.AreEqual(2, asol.Values[1]);
+            Assert.AreEqual(3, bsol.Values[0]);
         }
 
         /// <summary>
@@ -245,7 +246,7 @@ namespace ZenLib.Tests
 
             var assignment = new Dictionary<object, object>
             {
-                { a, new FSeq<int> { Values = new List<int> { 3, 2, 1 } } },
+                { a, new FSeq<int> { Values = ImmutableList.CreateRange(new List<int> { 3, 2, 1 }) } },
             };
 
             var l = expr.Evaluate(assignment);

--- a/ZenLibTests/FSeqTests.cs
+++ b/ZenLibTests/FSeqTests.cs
@@ -26,7 +26,7 @@ namespace ZenLib.Tests
         public void TestSeqToArray()
         {
             var a1 = new int[] { 1, 2, 3, 4 };
-            var s = FSeq.FromArray(a1);
+            var s = FSeq.FromRange(a1);
             var a2 = s.Values.ToArray();
             Assert.AreEqual(a1.Length, a2.Length);
 

--- a/ZenLibTests/StringTests.cs
+++ b/ZenLibTests/StringTests.cs
@@ -418,7 +418,7 @@ namespace ZenLib.Tests
         [ExpectedException(typeof(ZenException))]
         public void TestStringEqualityCompositeException2()
         {
-            CheckAgreement<IDictionary<string, string>, IDictionary<string, string>>((l1, l2) => l1 == l2);
+            CheckAgreement<Map<string, string>, Map<string, string>>((l1, l2) => l1 == l2);
         }
 
         /// <summary>

--- a/ZenLibTests/StringTests.cs
+++ b/ZenLibTests/StringTests.cs
@@ -387,7 +387,7 @@ namespace ZenLib.Tests
         [ExpectedException(typeof(ZenException))]
         public void TestStringEqualityCompositeException1()
         {
-            CheckAgreement<IList<string>, IList<string>>((l1, l2) => l1 == l2);
+            CheckAgreement<FSeq<string>, FSeq<string>>((l1, l2) => l1 == l2);
         }
 
         /// <summary>
@@ -428,7 +428,7 @@ namespace ZenLib.Tests
         [ExpectedException(typeof(ZenException))]
         public void TestStringEqualityCompositeException3()
         {
-            CheckAgreement<Option<IList<string>>, Option<IList<string>>>((l1, l2) => l1 == l2);
+            CheckAgreement<Option<FSeq<string>>, Option<FSeq<string>>>((l1, l2) => l1 == l2);
         }
 
         /// <summary>
@@ -438,7 +438,7 @@ namespace ZenLib.Tests
         [ExpectedException(typeof(ZenException))]
         public void TestStringEqualityCompositeException4()
         {
-            CheckAgreement<(string, IList<string>), (string, IList<string>)>((l1, l2) => l1 == l2);
+            CheckAgreement<(string, FSeq<string>), (string, FSeq<string>)>((l1, l2) => l1 == l2);
         }
 
         /// <summary>

--- a/ZenLibTests/StringTests.cs
+++ b/ZenLibTests/StringTests.cs
@@ -5,7 +5,6 @@
 namespace ZenLib.Tests
 {
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Numerics;
     using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/ZenLibTests/UtilityTests.cs
+++ b/ZenLibTests/UtilityTests.cs
@@ -68,7 +68,7 @@ namespace ZenLib.Tests
         public void TestSplitHead()
         {
             var list = ImmutableList<int>.Empty.Add(1).Add(2);
-            var (hd, tl) = CommonUtilities.SplitHead(list);
+            var (hd, tl) = CommonUtilities.SplitHeadHelper(list);
             Assert.AreEqual(1, hd);
             Assert.AreEqual(1, tl.Count);
         }
@@ -81,7 +81,7 @@ namespace ZenLib.Tests
         public void TestSplitHeadEmpty()
         {
             var list = ImmutableList<int>.Empty;
-            var _ = CommonUtilities.SplitHead(list);
+            var _ = CommonUtilities.SplitHeadHelper(list);
         }
 
         /// <summary>


### PR DESCRIPTION
Avoids the extra overhead of wrapping IDIctionary and IList in Map and FSeq and just directly uses those types for modeling.