### PR TITLE
Zen lazy symbolic execution

### DIFF
--- a/ZenLib.Bench/Program.cs
+++ b/ZenLib.Bench/Program.cs
@@ -23,11 +23,6 @@ namespace ZenLibBench
             // BenchmarkTransformers();
             // BenchmarkTransformerCache();
             // BenchmarkAllocation();
-
-            foreach (var input in Zen.GenerateInputs<FSeq<int>, FSeq<int>>(l => l.Sort(), depth: 8))
-            {
-                Console.WriteLine(input);
-            }
         }
 
         private static void BenchmarkComparisons()

--- a/ZenLib.Bench/Program.cs
+++ b/ZenLib.Bench/Program.cs
@@ -19,10 +19,22 @@ namespace ZenLibBench
         {
             Settings.UseLargeStack = true;
 
-            BenchmarkComparisons();
+            // BenchmarkComparisons();
             // BenchmarkTransformers();
             // BenchmarkTransformerCache();
             // BenchmarkAllocation();
+
+            /* var f = new ZenFunction<BigInteger, int>(x => Zen.If(x == new BigInteger(10), 1, Zen.If<int>(x == new BigInteger(20), 2, 3)));
+            foreach (var input in f.GenerateInputs(depth: 3, exhaustiveDepth: false))
+            {
+                Console.WriteLine(input);
+            } */
+
+            var f = new ZenFunction<FSeq<int>, FSeq<int>>(x => x.Sort());
+            foreach (var input in f.GenerateInputs(depth: 3, exhaustiveDepth: true))
+            {
+                Console.WriteLine(input);
+            }
         }
 
         private static void BenchmarkComparisons()

--- a/ZenLib.Bench/Program.cs
+++ b/ZenLib.Bench/Program.cs
@@ -24,14 +24,7 @@ namespace ZenLibBench
             // BenchmarkTransformerCache();
             // BenchmarkAllocation();
 
-            /* var f = new ZenFunction<BigInteger, int>(x => Zen.If(x == new BigInteger(10), 1, Zen.If<int>(x == new BigInteger(20), 2, 3)));
-            foreach (var input in f.GenerateInputs(depth: 3, exhaustiveDepth: false))
-            {
-                Console.WriteLine(input);
-            } */
-
-            var f = new ZenFunction<FSeq<int>, FSeq<int>>(x => x.Sort());
-            foreach (var input in f.GenerateInputs(depth: 3, exhaustiveDepth: true))
+            foreach (var input in Zen.GenerateInputs<FSeq<int>, FSeq<int>>(l => l.Sort(), depth: 8))
             {
                 Console.WriteLine(input);
             }

--- a/ZenLib.Tests/ApiTests.cs
+++ b/ZenLib.Tests/ApiTests.cs
@@ -1,0 +1,67 @@
+﻿// <copyright file="ApiTests.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace ZenLib.Tests
+{
+    using System.Diagnostics.CodeAnalysis;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using ZenLib;
+
+    /// <summary>
+    /// Tests for the Zen object type.
+    /// </summary>
+    [TestClass]
+    [ExcludeFromCodeCoverage]
+    public class ApiTests
+    {
+        /// <summary>
+        /// Test that the solve method is working with evaluate.
+        /// </summary>
+        [TestMethod]
+        public void TestSolve()
+        {
+            var x = Zen.Symbolic<int>();
+            var solution = (x + 1 == 5).Solve();
+
+            Assert.IsTrue(solution.IsSatisfiable());
+            Assert.AreEqual(4, solution.VariableAssignment[x]);
+        }
+
+        /// <summary>
+        /// Test that the evaluation function is working.
+        /// </summary>
+        [TestMethod]
+        public void TestEvaluate()
+        {
+            Assert.AreEqual(int.MinValue, Zen.Evaluate((a) => a + 1, int.MaxValue));
+
+            Assert.AreEqual(1, Zen.Evaluate(() => Zen.Constant(1)));
+            Assert.AreEqual(2, Zen.Evaluate((a) => a + 1, 1));
+            Assert.AreEqual(3, Zen.Evaluate((a, b) => a + b, 1, 2));
+            Assert.AreEqual(6, Zen.Evaluate((a, b, c) => a + b + c, 1, 2, 3));
+            Assert.AreEqual(10, Zen.Evaluate((a, b, c, d) => a + b + c + d, 1, 2, 3, 4));
+        }
+
+        /// <summary>
+        /// Test that the compilation function is working.
+        /// </summary>
+        [TestMethod]
+        public void TestCompile()
+        {
+            var f1 = Zen.Compile<int>(() => 1);
+            var f2 = Zen.Compile<int, int>((a) => a + 1);
+            var f3 = Zen.Compile<int, int, int>((a, b) => a + b);
+            var f4 = Zen.Compile<int, int, int, int>((a, b, c) => a + b + c);
+            var f5 = Zen.Compile<int, int, int, int, int>((a, b, c, d) => a + b + c + d);
+
+            Assert.AreEqual(int.MinValue, f2(int.MaxValue));
+
+            Assert.AreEqual(1, f1());
+            Assert.AreEqual(2, f2(1));
+            Assert.AreEqual(3, f3(1, 2));
+            Assert.AreEqual(6, f4(1, 2, 3));
+            Assert.AreEqual(10, f5(1, 2, 3, 4));
+        }
+    }
+}

--- a/ZenLib.Tests/FSeqTests.cs
+++ b/ZenLib.Tests/FSeqTests.cs
@@ -80,7 +80,7 @@ namespace ZenLib.Tests
         public void TestSeqAnyObjects()
         {
             var f1 = new ZenFunction<FSeq<Object2>, bool>(l => l.Any(e => e.GetField<Object2, int>("Field1") == 7));
-            var f2 = new ZenFunction<FSeq<Object2>, bool>(l => l.Any(e => e.GetField<Object2, int>("Field1") == 7).Simplify());
+            var f2 = new ZenFunction<FSeq<Object2>, bool>(l => l.Any(e => e.GetField<Object2, int>("Field1") == 7));
             var f3 = new ZenFunction<FSeq<Object2>, bool>(l => l.Any(e => e.GetField<Object2, int>("Field2") == 7));
 
             var input1 = f1.Find((i, o) => o);

--- a/ZenLib.Tests/RealTests.cs
+++ b/ZenLib.Tests/RealTests.cs
@@ -203,12 +203,11 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestRealAdd()
         {
+            Assert.AreEqual(new Real(1, 3), Zen.Evaluate((a, b) => a + b, new Real(0), new Real(1, 3)));
+            Assert.AreEqual(new Real(4, 3), Zen.Evaluate((a, b) => a + b, new Real(2, 2), new Real(1, 3)));
+            Assert.AreEqual(new Real(13, 21), Zen.Evaluate((a, b) => a + b, new Real(2, 7), new Real(1, 3)));
+
             var zf = new ZenFunction<Real, Real, Real>((a, b) => a + b);
-
-            Assert.AreEqual(new Real(1, 3), zf.Evaluate(new Real(0), new Real(1, 3)));
-            Assert.AreEqual(new Real(4, 3), zf.Evaluate(new Real(2, 2), new Real(1, 3)));
-            Assert.AreEqual(new Real(13, 21), zf.Evaluate(new Real(2, 7), new Real(1, 3)));
-
             zf.Compile();
 
             Assert.AreEqual(new Real(1, 3), zf.Evaluate(new Real(0), new Real(1, 3)));

--- a/ZenLib.Tests/SimplifierTests.cs
+++ b/ZenLib.Tests/SimplifierTests.cs
@@ -273,6 +273,33 @@ namespace ZenLib.Tests
         }
 
         /// <summary>
+        /// Simplify for addition.
+        /// </summary>
+        [TestMethod]
+        public void TestArithmeticSimplification()
+        {
+            var x = Zen.Symbolic<Real>("x");
+            var y = Zen.Symbolic<BigInteger>("y");
+
+            Assert.AreEqual(x, x + new Real(0));
+            Assert.AreEqual(x, new Real(0) + x);
+            Assert.AreEqual(y, y + BigInteger.Zero);
+            Assert.AreEqual(y, BigInteger.Zero + y);
+
+            Assert.AreEqual(x, x - new Real(0));
+            Assert.AreEqual(y, y - BigInteger.Zero);
+
+            Assert.AreEqual(x, x * new Real(1));
+            Assert.AreEqual(x, new Real(1) * x);
+            Assert.AreEqual(new Real(0), x * new Real(0));
+            Assert.AreEqual(new Real(0), new Real(0) * x);
+            Assert.AreEqual(y, y * BigInteger.One);
+            Assert.AreEqual(y, BigInteger.One * y);
+            Assert.AreEqual(Constant(BigInteger.Zero), y * BigInteger.Zero);
+            Assert.AreEqual(Constant(BigInteger.Zero), BigInteger.Zero * y);
+        }
+
+        /// <summary>
         /// Simplify for subtraction.
         /// </summary>
         [TestMethod]

--- a/ZenLib.Tests/StateSetTests.cs
+++ b/ZenLib.Tests/StateSetTests.cs
@@ -131,14 +131,14 @@ namespace ZenLib.Tests
         public void TestStateSetArgTypes()
         {
             var manager = new StateSetTransformerManager(0);
-            Assert.IsTrue(new ZenFunction<bool, bool>(b => true).StateSet(manager).IsFull());
-            Assert.IsTrue(new ZenFunction<byte, bool>(b => true).StateSet(manager).IsFull());
-            Assert.IsTrue(new ZenFunction<short, bool>(b => true).StateSet(manager).IsFull());
-            Assert.IsTrue(new ZenFunction<ushort, bool>(b => true).StateSet(manager).IsFull());
-            Assert.IsTrue(new ZenFunction<int, bool>(b => true).StateSet(manager).IsFull());
-            Assert.IsTrue(new ZenFunction<uint, bool>(b => true).StateSet(manager).IsFull());
-            Assert.IsTrue(new ZenFunction<long, bool>(b => true).StateSet(manager).IsFull());
-            Assert.IsTrue(new ZenFunction<ulong, bool>(b => true).StateSet(manager).IsFull());
+            Assert.IsTrue(Zen.StateSet<bool>(b => true, manager).IsFull());
+            Assert.IsTrue(Zen.StateSet<byte>(b => true, manager).IsFull());
+            Assert.IsTrue(Zen.StateSet<short>(b => true, manager).IsFull());
+            Assert.IsTrue(Zen.StateSet<ushort>(b => true, manager).IsFull());
+            Assert.IsTrue(Zen.StateSet<int>(b => true, manager).IsFull());
+            Assert.IsTrue(Zen.StateSet<uint>(b => true, manager).IsFull());
+            Assert.IsTrue(Zen.StateSet<long>(b => true, manager).IsFull());
+            Assert.IsTrue(Zen.StateSet<ulong>(b => true, manager).IsFull());
         }
 
         /// <summary>
@@ -340,12 +340,12 @@ namespace ZenLib.Tests
             var m1 = new StateSetTransformerManager();
             var m2 = new StateSetTransformerManager();
 
-            var f1 = new ZenFunction<byte, bool>(x => true).StateSet();
-            var f2 = new ZenFunction<byte, bool>(x => true).StateSet();
-            var f3 = new ZenFunction<byte, bool>(x => true).StateSet(m1);
-            var f4 = new ZenFunction<byte, bool>(x => true).StateSet(m1);
-            var f5 = new ZenFunction<byte, bool>(x => true).StateSet(m2);
-            var f6 = new ZenFunction<byte, bool>(x => true).StateSet(m2);
+            var f1 = Zen.StateSet<byte>(x => true);
+            var f2 = Zen.StateSet<byte>(x => true);
+            var f3 = Zen.StateSet<byte>(x => true, m1);
+            var f4 = Zen.StateSet<byte>(x => true, m1);
+            var f5 = Zen.StateSet<byte>(x => true, m2);
+            var f6 = Zen.StateSet<byte>(x => true, m2);
 
             Assert.IsTrue(ReferenceEquals(f1, f2));
             Assert.IsTrue(ReferenceEquals(f3, f4));
@@ -363,12 +363,12 @@ namespace ZenLib.Tests
             var m1 = new StateSetTransformerManager();
             var m2 = new StateSetTransformerManager();
 
-            var f1 = new ZenFunction<byte, byte, bool>((x, y) => true).StateSet();
-            var f2 = new ZenFunction<byte, byte, bool>((x, y) => true).StateSet();
-            var f3 = new ZenFunction<byte, byte, bool>((x, y) => true).StateSet(m1);
-            var f4 = new ZenFunction<byte, byte, bool>((x, y) => true).StateSet(m1);
-            var f5 = new ZenFunction<byte, byte, bool>((x, y) => true).StateSet(m2);
-            var f6 = new ZenFunction<byte, byte, bool>((x, y) => true).StateSet(m2);
+            var f1 = Zen.StateSet<byte, byte>((x, y) => true);
+            var f2 = Zen.StateSet<byte, byte>((x, y) => true);
+            var f3 = Zen.StateSet<byte, byte>((x, y) => true, m1);
+            var f4 = Zen.StateSet<byte, byte>((x, y) => true, m1);
+            var f5 = Zen.StateSet<byte, byte>((x, y) => true, m2);
+            var f6 = Zen.StateSet<byte, byte>((x, y) => true, m2);
 
             Assert.IsTrue(ReferenceEquals(f1, f2));
             Assert.IsTrue(ReferenceEquals(f3, f4));
@@ -386,12 +386,12 @@ namespace ZenLib.Tests
             var m1 = new StateSetTransformerManager();
             var m2 = new StateSetTransformerManager();
 
-            var f1 = new ZenFunction<byte, byte, byte, bool>((x, y, z) => true).StateSet();
-            var f2 = new ZenFunction<byte, byte, byte, bool>((x, y, z) => true).StateSet();
-            var f3 = new ZenFunction<byte, byte, byte, bool>((x, y, z) => true).StateSet(m1);
-            var f4 = new ZenFunction<byte, byte, byte, bool>((x, y, z) => true).StateSet(m1);
-            var f5 = new ZenFunction<byte, byte, byte, bool>((x, y, z) => true).StateSet(m2);
-            var f6 = new ZenFunction<byte, byte, byte, bool>((x, y, z) => true).StateSet(m2);
+            var f1 = Zen.StateSet<byte, byte, byte>((x, y, z) => true);
+            var f2 = Zen.StateSet<byte, byte, byte>((x, y, z) => true);
+            var f3 = Zen.StateSet<byte, byte, byte>((x, y, z) => true, m1);
+            var f4 = Zen.StateSet<byte, byte, byte>((x, y, z) => true, m1);
+            var f5 = Zen.StateSet<byte, byte, byte>((x, y, z) => true, m2);
+            var f6 = Zen.StateSet<byte, byte, byte>((x, y, z) => true, m2);
 
             Assert.IsTrue(ReferenceEquals(f1, f2));
             Assert.IsTrue(ReferenceEquals(f3, f4));
@@ -409,12 +409,12 @@ namespace ZenLib.Tests
             var m1 = new StateSetTransformerManager();
             var m2 = new StateSetTransformerManager();
 
-            var f1 = new ZenFunction<byte, byte, byte, byte, bool>((w, x, y, z) => true).StateSet();
-            var f2 = new ZenFunction<byte, byte, byte, byte, bool>((w, x, y, z) => true).StateSet();
-            var f3 = new ZenFunction<byte, byte, byte, byte, bool>((w, x, y, z) => true).StateSet(m1);
-            var f4 = new ZenFunction<byte, byte, byte, byte, bool>((w, x, y, z) => true).StateSet(m1);
-            var f5 = new ZenFunction<byte, byte, byte, byte, bool>((w, x, y, z) => true).StateSet(m2);
-            var f6 = new ZenFunction<byte, byte, byte, byte, bool>((w, x, y, z) => true).StateSet(m2);
+            var f1 = Zen.StateSet<byte, byte, byte, byte>((w, x, y, z) => true);
+            var f2 = Zen.StateSet<byte, byte, byte, byte>((w, x, y, z) => true);
+            var f3 = Zen.StateSet<byte, byte, byte, byte>((w, x, y, z) => true, m1);
+            var f4 = Zen.StateSet<byte, byte, byte, byte>((w, x, y, z) => true, m1);
+            var f5 = Zen.StateSet<byte, byte, byte, byte>((w, x, y, z) => true, m2);
+            var f6 = Zen.StateSet<byte, byte, byte, byte>((w, x, y, z) => true, m2);
 
             Assert.IsTrue(ReferenceEquals(f1, f2));
             Assert.IsTrue(ReferenceEquals(f3, f4));

--- a/ZenLib.Tests/SymbolicExecutionTests.cs
+++ b/ZenLib.Tests/SymbolicExecutionTests.cs
@@ -27,8 +27,7 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestSymbolicExecutionStrings()
         {
-            var f = new ZenFunction<string, int>(x => If(x.Contains("a"), 1, If<int>(x.Contains("b"), 2, 3)));
-            Assert.AreEqual(3, f.GenerateInputs().Count());
+            Assert.AreEqual(3, Zen.GenerateInputs<string, int>(x => If(x.Contains("a"), 1, If<int>(x.Contains("b"), 2, 3))).Count());
         }
 
         /// <summary>
@@ -37,8 +36,7 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestSymbolicExecutionBigIntegers()
         {
-            var f = new ZenFunction<BigInteger, int>(x => If(x == new BigInteger(10), 1, If<int>(x == new BigInteger(20), 2, 3)));
-            Assert.AreEqual(3, f.GenerateInputs().Count());
+            Assert.AreEqual(3, Zen.GenerateInputs<BigInteger, int>(x => If(x == new BigInteger(10), 1, If<int>(x == new BigInteger(20), 2, 3))).Count());
         }
 
         /// <summary>
@@ -47,14 +45,10 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestSymbolicExecutionLogic()
         {
-            var f1 = new ZenFunction<int, int, bool>((x, y) => And(x == 1, y == 2));
-            var f2 = new ZenFunction<int, int, bool>((x, y) => Or(x == 1, y == 2));
-            var f3 = new ZenFunction<int, int, bool>((x, y) => Not(Or(x == 1, y == 2)));
-            var f4 = new ZenFunction<int, bool>(x => Or(x == 1, x == 2, x == 3));
-            Assert.AreEqual(1, f1.GenerateInputs().Count());
-            Assert.AreEqual(1, f2.GenerateInputs().Count());
-            Assert.AreEqual(1, f3.GenerateInputs().Count());
-            Assert.AreEqual(1, f4.GenerateInputs().Count());
+            Assert.AreEqual(1, Zen.GenerateInputs<int, int, bool>((x, y) => And(x == 1, y == 2)).Count());
+            Assert.AreEqual(1, Zen.GenerateInputs<int, int, bool>((x, y) => Or(x == 1, y == 2)).Count());
+            Assert.AreEqual(1, Zen.GenerateInputs<int, int, bool>((x, y) => Not(Or(x == 1, y == 2))).Count());
+            Assert.AreEqual(1, Zen.GenerateInputs<int, bool>(x => Or(x == 1, x == 2, x == 3)).Count());
         }
 
         /// <summary>
@@ -63,8 +57,7 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestSymbolicExecutionBitvectors()
         {
-            var f1 = new ZenFunction<int, int, int, int>((x, y, z) => ((x | y) & z) ^ x);
-            Assert.AreEqual(1, f1.GenerateInputs().Count());
+            Assert.AreEqual(1, Zen.GenerateInputs<int, int, int, int>((x, y, z) => ((x | y) & z) ^ x).Count());
         }
 
         /// <summary>
@@ -74,8 +67,7 @@ namespace ZenLib.Tests
         public void TestSymbolicExecutionStringOperations()
         {
             Settings.PreserveBranches = true;
-            var f = new ZenFunction<string, string, string, string, bool>((w, x, y, z) => If(w.EndsWith(x), True(), If(w.StartsWith(y), True(), w.Contains(z))));
-            Assert.AreEqual(3, f.GenerateInputs().Count());
+            Assert.AreEqual(3, Zen.GenerateInputs<string, string, string, string, bool>((w, x, y, z) => If(w.EndsWith(x), True(), If(w.StartsWith(y), True(), w.Contains(z)))).Count());
             Settings.PreserveBranches = false;
         }
 
@@ -86,8 +78,7 @@ namespace ZenLib.Tests
         public void TestSymbolicExecutionListContains()
         {
             Settings.PreserveBranches = true;
-            var f = new ZenFunction<FSeq<int>, bool>(x => x.Contains(3));
-            Assert.AreEqual(6, f.GenerateInputs().Count());
+            Assert.AreEqual(6, Zen.GenerateInputs<FSeq<int>, bool>(x => x.Contains(3)).Count());
             Settings.PreserveBranches = false;
         }
 
@@ -103,12 +94,23 @@ namespace ZenLib.Tests
         }
 
         /// <summary>
+        /// Test symbolic execution for lists.
+        /// </summary>
+        [TestMethod]
+        public void TestSymbolicExecutionListFilter()
+        {
+            var f = new ZenFunction<FSeq<int>, FSeq<int>>(x => x.Where(e => e >= 4));
+            Assert.AreEqual(8, f.GenerateInputs(depth: 3, exhaustiveDepth: false).Count());
+            Assert.AreEqual(15, f.GenerateInputs(depth: 3, exhaustiveDepth: true).Count());
+        }
+
+        /// <summary>
         /// Test symbolic execution for an ite chain.
         /// </summary>
         [TestMethod]
         public void TestSymbolicExecutionIfThenElse()
         {
-            var f = new ZenFunction<int, int, int, int>((x, y, z) =>
+            var f = Zen.Function<int, int, int, int>((x, y, z) =>
             {
                 return If(x > 10, 1, If(y > x, If<int>(z > 10, 2, 3), If<int>(z > y, 4, 5)));
             });
@@ -140,8 +142,7 @@ namespace ZenLib.Tests
             var lines = new AclLine[2] { aclLine1, aclLine2 };
             var acl = new Acl { Lines = lines };
 
-            var f = new ZenFunction<IpHeader, bool>(h => acl.Process(h, 0));
-            Assert.AreEqual(3, f.GenerateInputs().Count());
+            Assert.AreEqual(3, Zen.GenerateInputs<IpHeader, bool>(h => acl.Process(h, 0)).Count());
             Settings.PreserveBranches = false;
         }
 
@@ -164,8 +165,7 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestSymbolicExecutionOptions()
         {
-            var f = new ZenFunction<Option<int>, Option<int>>(x => x.Where(v => v == 1));
-            Assert.AreEqual(2, f.GenerateInputs().Count());
+            Assert.AreEqual(2, Zen.GenerateInputs<Option<int>, Option<int>>(x => x.Where(v => v == 1)).Count());
         }
 
         /// <summary>
@@ -174,8 +174,7 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestSymbolicExecutionStringAt()
         {
-            var f = new ZenFunction<string, bool, string>((s, b) => s.At(If<BigInteger>(b, new BigInteger(1), new BigInteger(2))));
-            Assert.AreEqual(2, f.GenerateInputs().Count());
+            Assert.AreEqual(2, Zen.GenerateInputs<string, bool, string>((s, b) => s.At(If<BigInteger>(b, new BigInteger(1), new BigInteger(2)))).Count());
         }
 
         /// <summary>
@@ -184,8 +183,7 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestSymbolicExecutionStringSubstring()
         {
-            var f = new ZenFunction<string, bool, string>((s, b) => s.Slice(new BigInteger(0), If<BigInteger>(b, new BigInteger(1), new BigInteger(2))));
-            Assert.AreEqual(2, f.GenerateInputs().Count());
+            Assert.AreEqual(2, Zen.GenerateInputs<string, bool, string>((s, b) => s.Slice(new BigInteger(0), If<BigInteger>(b, new BigInteger(1), new BigInteger(2)))).Count());
         }
 
         /// <summary>
@@ -194,8 +192,7 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestSymbolicExecutionStringReplace()
         {
-            var f = new ZenFunction<string, bool, string>((s, b) => s.ReplaceFirst("hello", If<string>(b, "x", "y")));
-            Assert.AreEqual(2, f.GenerateInputs().Count());
+            Assert.AreEqual(2, Zen.GenerateInputs<string, bool, string>((s, b) => s.ReplaceFirst("hello", If<string>(b, "x", "y"))).Count());
         }
 
         /// <summary>
@@ -220,10 +217,8 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestSymbolicExecutionStringLength()
         {
-            var f1 = new ZenFunction<string, int>(s => If<int>(s.Length() == new BigInteger(3), 1, 2));
-            var f2 = new ZenFunction<string, int>(s => If(s.Length() == new BigInteger(3), If<int>(s.Length() == new BigInteger(2), 1, 2), 3));
-            Assert.AreEqual(2, f1.GenerateInputs().Count());
-            Assert.AreEqual(2, f2.GenerateInputs().Count());
+            Assert.AreEqual(2, Zen.GenerateInputs<string, int>(s => If<int>(s.Length() == new BigInteger(3), 1, 2)).Count());
+            Assert.AreEqual(2, Zen.GenerateInputs<string, int>(s => If(s.Length() == new BigInteger(3), If<int>(s.Length() == new BigInteger(2), 1, 2), 3)).Count());
         }
 
         /// <summary>
@@ -232,8 +227,7 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestSymbolicExecutionStringIndexOf()
         {
-            var f = new ZenFunction<string, bool, BigInteger>((s, b) => s.IndexOf(If<string>(b, "hello", "world)")));
-            Assert.AreEqual(2, f.GenerateInputs().Count());
+            Assert.AreEqual(2, Zen.GenerateInputs<string, bool, BigInteger>((s, b) => s.IndexOf(If<string>(b, "hello", "world)"))).Count());
         }
 
         /// <summary>

--- a/ZenLib.Tests/TestHelper.cs
+++ b/ZenLib.Tests/TestHelper.cs
@@ -17,6 +17,9 @@ namespace ZenLib.Tests
     [ExcludeFromCodeCoverage]
     public static class TestHelper
     {
+        /// <summary>
+        /// The default bdd list size.
+        /// </summary>
         private static int defaultBddListSize = 4;
 
         /// <summary>
@@ -80,9 +83,9 @@ namespace ZenLib.Tests
             return (byte)random.Next(0, 255);
         }
 
-        private static Zen<T> Simplify<T>(Zen<T> expr, TestParameter p)
+        private static Zen<T> Flatten<T>(Zen<T> expr, TestParameter p)
         {
-            return p.Simplify ? expr.Simplify() : expr;
+            return p.Simplify ? expr.Flatten() : expr;
         }
 
         private static TestParameter[] GetBoundedParameters(int bddListSize, bool runBdds)
@@ -144,7 +147,7 @@ namespace ZenLib.Tests
             {
                 // prove that it is valid
                 var f = Zen.Function<T1, bool>(function);
-                var result = f.Find((i1, o) => Simplify(Not(o), p), depth: p.ListSize, backend: p.Backend);
+                var result = f.Find((i1, o) => Flatten(Not(o), p), depth: p.ListSize, backend: p.Backend);
                 Assert.IsFalse(result.HasValue);
 
                 // compare input with evaluation
@@ -173,11 +176,11 @@ namespace ZenLib.Tests
             {
                 // prove that it is valid
                 var f = Zen.Function<T1, T2, bool>(function);
-                var result = f.Find((i1, i2, o) => Simplify(Not(o), p), depth: p.ListSize, backend: p.Backend);
+                var result = f.Find((i1, i2, o) => Flatten(Not(o), p), depth: p.ListSize, backend: p.Backend);
                 Assert.IsFalse(result.HasValue);
 
                 // compare input with evaluation
-                result = f.Find((i1, i2, o) => Simplify(o, p), depth: p.ListSize, backend: p.Backend);
+                result = f.Find((i1, i2, o) => Flatten(o, p), depth: p.ListSize, backend: p.Backend);
                 Assert.IsTrue(result.HasValue);
 
                 Assert.IsTrue(f.Evaluate(result.Value.Item1, result.Value.Item2));
@@ -202,11 +205,11 @@ namespace ZenLib.Tests
             {
                 // prove that it is valid
                 var f = Zen.Function<T1, T2, T3, bool>(function);
-                var result = f.Find((i1, i2, i3, o) => Simplify(Not(o), p), depth: p.ListSize, backend: p.Backend);
+                var result = f.Find((i1, i2, i3, o) => Flatten(Not(o), p), depth: p.ListSize, backend: p.Backend);
                 Assert.IsFalse(result.HasValue);
 
                 // compare input with evaluation
-                result = f.Find((i1, i2, i3, o) => Simplify(o, p), depth: p.ListSize, backend: p.Backend);
+                result = f.Find((i1, i2, i3, o) => Flatten(o, p), depth: p.ListSize, backend: p.Backend);
                 Assert.IsTrue(result.HasValue);
 
                 Assert.IsTrue(f.Evaluate(result.Value.Item1, result.Value.Item2, result.Value.Item3));
@@ -232,11 +235,11 @@ namespace ZenLib.Tests
             {
                 // prove that it is valid
                 var f = Zen.Function<T1, T2, T3, T4, bool>(function);
-                var result = f.Find((i1, i2, i3, i4, o) => Simplify(Not(o), p), depth: p.ListSize, backend: p.Backend);
+                var result = f.Find((i1, i2, i3, i4, o) => Flatten(Not(o), p), depth: p.ListSize, backend: p.Backend);
                 Assert.IsFalse(result.HasValue);
 
                 // compare input with evaluation
-                result = f.Find((i1, i2, i3, i4, o) => Simplify(o, p), depth: p.ListSize, backend: p.Backend);
+                result = f.Find((i1, i2, i3, i4, o) => Flatten(o, p), depth: p.ListSize, backend: p.Backend);
                 Assert.IsTrue(result.HasValue);
 
                 Assert.IsTrue(f.Evaluate(result.Value.Item1, result.Value.Item2, result.Value.Item3, result.Value.Item4));
@@ -259,7 +262,7 @@ namespace ZenLib.Tests
             {
                 // prove that it is not valid
                 var f = Zen.Function<T1, bool>(function);
-                var result = f.Find((i1, o) => Simplify(Not(o), p), depth: p.ListSize, backend: p.Backend);
+                var result = f.Find((i1, o) => Flatten(Not(o), p), depth: p.ListSize, backend: p.Backend);
                 Assert.IsTrue(result.HasValue);
 
                 // compare input with evaluation
@@ -283,7 +286,7 @@ namespace ZenLib.Tests
             foreach (var p in selectedParams)
             {
                 var f = Zen.Function<T1, T2, bool>(function);
-                var result = f.Find((i1, i2, o) => Simplify(Not(o), p), depth: p.ListSize, backend: p.Backend);
+                var result = f.Find((i1, i2, o) => Flatten(Not(o), p), depth: p.ListSize, backend: p.Backend);
                 Assert.IsTrue(result.HasValue);
 
                 // compare input with evaluation
@@ -303,7 +306,7 @@ namespace ZenLib.Tests
             foreach (var p in GetBoundedParameters(defaultBddListSize, runBdds))
             {
                 var f = Zen.Function<bool>(function);
-                var result = f.Assert(o => Simplify(o, p), backend: p.Backend);
+                var result = f.Assert(o => Flatten(o, p), backend: p.Backend);
 
                 Assert.AreEqual(f.Evaluate(), result);
                 f.Compile();
@@ -324,7 +327,7 @@ namespace ZenLib.Tests
             foreach (var p in selectedParams)
             {
                 var f = Zen.Function<T1, bool>(function);
-                var result = f.Find((i1, o) => Simplify(o, p), depth: p.ListSize, backend: p.Backend);
+                var result = f.Find((i1, o) => Flatten(o, p), depth: p.ListSize, backend: p.Backend);
                 if (result.HasValue)
                 {
                     Assert.IsTrue(f.Evaluate(result.Value));
@@ -349,7 +352,7 @@ namespace ZenLib.Tests
             foreach (var p in selectedParams)
             {
                 var f = Zen.Function<T1, T2, bool>(function);
-                var result = f.Find((i1, i2, o) => Simplify(o, p), depth: p.ListSize, backend: p.Backend);
+                var result = f.Find((i1, i2, o) => Flatten(o, p), depth: p.ListSize, backend: p.Backend);
 
                 if (result.HasValue)
                 {

--- a/ZenLib.Tests/TransformerTests.cs
+++ b/ZenLib.Tests/TransformerTests.cs
@@ -173,14 +173,14 @@ namespace ZenLib.Tests
         public void TestTransformerArgTypes()
         {
             var manager = new StateSetTransformerManager(0);
-            Assert.IsTrue(new ZenFunction<bool, bool>(b => true).Transformer(manager).InputSet((i, o) => o).IsFull());
-            Assert.IsTrue(new ZenFunction<byte, bool>(b => true).Transformer(manager).InputSet((i, o) => o).IsFull());
-            Assert.IsTrue(new ZenFunction<short, bool>(b => true).Transformer(manager).InputSet((i, o) => o).IsFull());
-            Assert.IsTrue(new ZenFunction<ushort, bool>(b => true).Transformer(manager).InputSet((i, o) => o).IsFull());
-            Assert.IsTrue(new ZenFunction<int, bool>(b => true).Transformer(manager).InputSet((i, o) => o).IsFull());
-            Assert.IsTrue(new ZenFunction<uint, bool>(b => true).Transformer(manager).InputSet((i, o) => o).IsFull());
-            Assert.IsTrue(new ZenFunction<long, bool>(b => true).Transformer(manager).InputSet((i, o) => o).IsFull());
-            Assert.IsTrue(new ZenFunction<ulong, bool>(b => true).Transformer(manager).InputSet((i, o) => o).IsFull());
+            Assert.IsTrue(Zen.Transformer<bool, bool>(b => true, manager).InputSet((i, o) => o).IsFull());
+            Assert.IsTrue(Zen.Transformer<byte, bool>(b => true, manager).InputSet((i, o) => o).IsFull());
+            Assert.IsTrue(Zen.Transformer<short, bool>(b => true, manager).InputSet((i, o) => o).IsFull());
+            Assert.IsTrue(Zen.Transformer<ushort, bool>(b => true, manager).InputSet((i, o) => o).IsFull());
+            Assert.IsTrue(Zen.Transformer<int, bool>(b => true, manager).InputSet((i, o) => o).IsFull());
+            Assert.IsTrue(Zen.Transformer<uint, bool>(b => true, manager).InputSet((i, o) => o).IsFull());
+            Assert.IsTrue(Zen.Transformer<long, bool>(b => true, manager).InputSet((i, o) => o).IsFull());
+            Assert.IsTrue(Zen.Transformer<ulong, bool>(b => true, manager).InputSet((i, o) => o).IsFull());
         }
 
         /// <summary>
@@ -345,9 +345,9 @@ namespace ZenLib.Tests
         public void TestTransformersMultipleArguments()
         {
             var manager = new StateSetTransformerManager(0);
-            var t1 = new ZenFunction<uint, uint, uint>((x, y) => x).Transformer(manager);
-            var t2 = new ZenFunction<uint, uint, uint, uint>((x, y, z) => y).Transformer(manager);
-            var t3 = new ZenFunction<uint, uint, uint, uint, uint>((w, x, y, z) => y).Transformer(manager);
+            var t1 = Zen.Transformer<uint, uint, uint>((x, y) => x, manager);
+            var t2 = Zen.Transformer<uint, uint, uint, uint>((x, y, z) => y, manager);
+            var t3 = Zen.Transformer<uint, uint, uint, uint, uint>((w, x, y, z) => y, manager);
 
             Assert.AreEqual(3U, t1.OutputSet((p, o) => p.Item1() == 3U).Element());
             Assert.AreEqual(3U, t2.OutputSet((p, o) => p.Item2() == 3U).Element());
@@ -361,8 +361,8 @@ namespace ZenLib.Tests
         [ExpectedException(typeof(ZenException))]
         public void TestTransformerInvalidArguments1()
         {
-            var t1 = new ZenFunction<uint, bool>(x => true).Transformer(new StateSetTransformerManager());
-            var t2 = new ZenFunction<uint, bool>(x => true).Transformer(new StateSetTransformerManager());
+            var t1 = Zen.Transformer<uint, bool>(x => true, new StateSetTransformerManager());
+            var t2 = Zen.Transformer<uint, bool>(x => true, new StateSetTransformerManager());
 
             var set1 = t1.InputSet((i, o) => o);
             t2.TransformForward(set1);

--- a/ZenLib.Tests/UtilityTests.cs
+++ b/ZenLib.Tests/UtilityTests.cs
@@ -130,7 +130,7 @@ namespace ZenLib.Tests
                 y = Zen.If(x >= i, i, y);
             }
 
-            y.Simplify();
+            y.Flatten();
             Settings.UseLargeStack = false;
         }
 

--- a/ZenLib/Interpretation/ExpressionEvaluator.cs
+++ b/ZenLib/Interpretation/ExpressionEvaluator.cs
@@ -413,8 +413,6 @@ namespace ZenLib.Interpretation
 
                 if (this.trackBranches)
                 {
-                    // Console.WriteLine(expression.ListExpr.IsEmpty().Format());
-
                     this.PathConstraint.Add(Zen.Not(expression.ListExpr.IsEmpty()));
                     this.PathConstraintSymbolicEnvironment[argHd.ArgumentId] = expression.ListExpr.Head();
                     this.PathConstraintSymbolicEnvironment[argTl.ArgumentId] = expression.ListExpr.Tail();

--- a/ZenLib/Interpretation/ExpressionEvaluator.cs
+++ b/ZenLib/Interpretation/ExpressionEvaluator.cs
@@ -4,6 +4,7 @@
 
 namespace ZenLib.Interpretation
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Numerics;
@@ -32,6 +33,11 @@ namespace ZenLib.Interpretation
         public PathConstraint PathConstraint { get; set; }
 
         /// <summary>
+        /// Track the symbolic assignment to arguments when collecting path constraints.
+        /// </summary>
+        public Dictionary<long, object> PathConstraintSymbolicEnvironment { get; set; }
+
+        /// <summary>
         /// Cache of inputs and results.
         /// </summary>
         private Dictionary<object, object> cache = new Dictionary<object, object>();
@@ -44,9 +50,10 @@ namespace ZenLib.Interpretation
         {
             this.trackBranches = trackBranches;
 
-            if (trackBranches)
+            if (this.trackBranches)
             {
                 this.PathConstraint = new PathConstraint();
+                this.PathConstraintSymbolicEnvironment = new Dictionary<long, object>();
             }
         }
 
@@ -235,7 +242,7 @@ namespace ZenLib.Interpretation
 
             if (e1)
             {
-                if (trackBranches)
+                if (this.trackBranches)
                 {
                     this.PathConstraint = this.PathConstraint.Add(expression.GuardExpr);
                 }
@@ -244,7 +251,7 @@ namespace ZenLib.Interpretation
             }
             else
             {
-                if (trackBranches)
+                if (this.trackBranches)
                 {
                     this.PathConstraint = this.PathConstraint.Add(ZenNotExpr.Create(expression.GuardExpr));
                 }
@@ -389,12 +396,31 @@ namespace ZenLib.Interpretation
 
             if (e.Count() == 0)
             {
+                if (this.trackBranches)
+                {
+                    this.PathConstraint.Add(expression.ListExpr.IsEmpty());
+                }
+
                 return Evaluate(expression.EmptyCase, parameter);
             }
             else
             {
                 var (hd, tl) = CommonUtilities.SplitHead(e);
-                var c = expression.ConsCase.Invoke(Constant(hd), Constant(tl));
+                var argHd = new ZenArgumentExpr<T>();
+                var argTl = new ZenArgumentExpr<FSeq<T>>();
+                parameter.ArgumentAssignment[argHd.ArgumentId] = hd;
+                parameter.ArgumentAssignment[argTl.ArgumentId] = tl;
+
+                if (this.trackBranches)
+                {
+                    // Console.WriteLine(expression.ListExpr.IsEmpty().Format());
+
+                    this.PathConstraint.Add(Zen.Not(expression.ListExpr.IsEmpty()));
+                    this.PathConstraintSymbolicEnvironment[argHd.ArgumentId] = expression.ListExpr.Head();
+                    this.PathConstraintSymbolicEnvironment[argTl.ArgumentId] = expression.ListExpr.Tail();
+                }
+
+                var c = expression.ConsCase.Invoke(argHd, argTl);
                 return (TResult)Evaluate(c, parameter);
             }
         }
@@ -541,7 +567,7 @@ namespace ZenLib.Interpretation
             else if (typeof(TKey) == ReflectionUtilities.UnicodeSequenceType)
             {
                 Contract.Assert(typeof(TKey) == ReflectionUtilities.UnicodeSequenceType);
-                return Seq.AsString((Seq<Char>)e);
+                return Seq.AsString((Seq<ZenLib.Char>)e);
             }
             else
             {

--- a/ZenLib/Interpretation/ExpressionEvaluatorEnvironment.cs
+++ b/ZenLib/Interpretation/ExpressionEvaluatorEnvironment.cs
@@ -5,7 +5,6 @@
 namespace ZenLib.Interpretation
 {
     using System.Collections.Generic;
-    using System.Collections.Immutable;
 
     /// <summary>
     /// An environment for the interpreter.

--- a/ZenLib/Interpretation/Interpreter.cs
+++ b/ZenLib/Interpretation/Interpreter.cs
@@ -24,12 +24,7 @@ namespace ZenLib.Interpretation
         /// <returns>The result and any path constraint.</returns>
         public static (T, PathConstraint) Run<T>(Zen<T> expression, Dictionary<long, object> args, bool trackBranches = false)
         {
-            return Interpret(expression, args, trackBranches);
-        }
-
-        private static (T, PathConstraint) Interpret<T>(Zen<T> expression, Dictionary<long, object> arguments, bool trackBranches)
-        {
-            var environment = new ExpressionEvaluatorEnvironment(arguments);
+            var environment = new ExpressionEvaluatorEnvironment(args);
             var interpreter = new ExpressionEvaluator(trackBranches);
             var result = (T)interpreter.Evaluate(expression, environment);
             return (result, interpreter.PathConstraint);
@@ -42,7 +37,7 @@ namespace ZenLib.Interpretation
             ImmutableDictionary<long, object> args)
         {
             var expression = function(Constant(value1), Constant(value2));
-            return Interpret(expression, new Dictionary<long, object>(args), false).Item1;
+            return Run(expression, new Dictionary<long, object>(args), false).Item1;
         }
     }
 }

--- a/ZenLib/SymbolicExecution/InputGenerator.cs
+++ b/ZenLib/SymbolicExecution/InputGenerator.cs
@@ -15,7 +15,10 @@ namespace ZenLib.SymbolicExecution
     /// </summary>
     internal static class InputGenerator
     {
-        private static Dictionary<long, object> arguments = new Dictionary<long, object>();
+        /// <summary>
+        /// The empty arguments.
+        /// </summary>
+        private static Dictionary<long, object> emptyArguments = new Dictionary<long, object>();
 
         /// <summary>
         /// Generate inputs that exercise different program paths.
@@ -31,18 +34,18 @@ namespace ZenLib.SymbolicExecution
             Zen<T1> input,
             Backend backend)
         {
-            var expression = function(input).Simplify();
-            var assume = precondition(input).Simplify();
+            var expression = function(input);
+            var assume = precondition(input);
 
-            (T2, PathConstraint) interpretFunction(T1 e)
+            (T2, PathConstraint, Dictionary<long, object>) interpretFunction(T1 e)
             {
-                var assignment = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, null, arguments).ModelCheck(input == e, arguments);
+                var assignment = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, null, emptyArguments).ModelCheck(input == e, emptyArguments);
                 var evaluator = new ExpressionEvaluator(true);
                 var env = new ExpressionEvaluatorEnvironment(assignment);
-                return ((T2)evaluator.Evaluate(expression, env), evaluator.PathConstraint);
+                return ((T2)evaluator.Evaluate(expression, env), evaluator.PathConstraint, evaluator.PathConstraintSymbolicEnvironment);
             }
 
-            Option<T1> findFunction(Zen<bool> e) => SymbolicEvaluator.Find(e, arguments, input, backend);
+            Option<T1> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input, backend);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }
@@ -63,20 +66,20 @@ namespace ZenLib.SymbolicExecution
             Zen<T2> input2,
             Backend backend)
         {
-            var expression = function(input1, input2).Simplify();
-            var assume = precondition(input1, input2).Simplify();
+            var expression = function(input1, input2);
+            var assume = precondition(input1, input2);
 
-            (T3, PathConstraint) interpretFunction((T1, T2) e)
+            (T3, PathConstraint, Dictionary<long, object>) interpretFunction((T1, T2) e)
             {
                 var assignment = ModelCheckerFactory
-                    .CreateModelChecker(backend, ModelCheckerContext.Solving, null, arguments)
-                    .ModelCheck(And(input1 == e.Item1, input2 == e.Item2), arguments);
+                    .CreateModelChecker(backend, ModelCheckerContext.Solving, null, emptyArguments)
+                    .ModelCheck(And(input1 == e.Item1, input2 == e.Item2), emptyArguments);
                 var evaluator = new ExpressionEvaluator(true);
                 var env = new ExpressionEvaluatorEnvironment(assignment);
-                return ((T3)evaluator.Evaluate(expression, env), evaluator.PathConstraint);
+                return ((T3)evaluator.Evaluate(expression, env), evaluator.PathConstraint, evaluator.PathConstraintSymbolicEnvironment);
             }
 
-            Option<(T1, T2)> findFunction(Zen<bool> e) => SymbolicEvaluator.Find(e, arguments, input1, input2, backend);
+            Option<(T1, T2)> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input1, input2, backend);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }
@@ -99,20 +102,20 @@ namespace ZenLib.SymbolicExecution
             Zen<T3> input3,
             Backend backend)
         {
-            var expression = function(input1, input2, input3).Simplify();
-            var assume = precondition(input1, input2, input3).Simplify();
+            var expression = function(input1, input2, input3);
+            var assume = precondition(input1, input2, input3);
 
-            (T4, PathConstraint) interpretFunction((T1, T2, T3) e)
+            (T4, PathConstraint, Dictionary<long, object>) interpretFunction((T1, T2, T3) e)
             {
                 var assignment = ModelCheckerFactory
-                    .CreateModelChecker(backend, ModelCheckerContext.Solving, null, arguments)
-                    .ModelCheck(And(input1 == e.Item1, input2 == e.Item2, input3 == e.Item3), arguments);
+                    .CreateModelChecker(backend, ModelCheckerContext.Solving, null, emptyArguments)
+                    .ModelCheck(And(input1 == e.Item1, input2 == e.Item2, input3 == e.Item3), emptyArguments);
                 var evaluator = new ExpressionEvaluator(true);
                 var env = new ExpressionEvaluatorEnvironment(assignment);
-                return ((T4)evaluator.Evaluate(expression, env), evaluator.PathConstraint);
+                return ((T4)evaluator.Evaluate(expression, env), evaluator.PathConstraint, evaluator.PathConstraintSymbolicEnvironment);
             }
 
-            Option<(T1, T2, T3)> findFunction(Zen<bool> e) => SymbolicEvaluator.Find(e, arguments, input1, input2, input3, backend);
+            Option<(T1, T2, T3)> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input1, input2, input3, backend);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }
@@ -137,20 +140,20 @@ namespace ZenLib.SymbolicExecution
             Zen<T4> input4,
             Backend backend)
         {
-            var expression = function(input1, input2, input3, input4).Simplify();
-            var assume = precondition(input1, input2, input3, input4).Simplify();
+            var expression = function(input1, input2, input3, input4);
+            var assume = precondition(input1, input2, input3, input4);
 
-            (T5, PathConstraint) interpretFunction((T1, T2, T3, T4) e)
+            (T5, PathConstraint, Dictionary<long, object>) interpretFunction((T1, T2, T3, T4) e)
             {
                 var assignment = ModelCheckerFactory
-                    .CreateModelChecker(backend, ModelCheckerContext.Solving, null, arguments)
-                    .ModelCheck(And(input1 == e.Item1, input2 == e.Item2, input3 == e.Item3, input4 == e.Item4), arguments);
+                    .CreateModelChecker(backend, ModelCheckerContext.Solving, null, emptyArguments)
+                    .ModelCheck(And(input1 == e.Item1, input2 == e.Item2, input3 == e.Item3, input4 == e.Item4), emptyArguments);
                 var evaluator = new ExpressionEvaluator(true);
                 var env = new ExpressionEvaluatorEnvironment(assignment);
-                return ((T5)evaluator.Evaluate(expression, env), evaluator.PathConstraint);
+                return ((T5)evaluator.Evaluate(expression, env), evaluator.PathConstraint, evaluator.PathConstraintSymbolicEnvironment);
             }
 
-            Option<(T1, T2, T3, T4)> findFunction(Zen<bool> e) => SymbolicEvaluator.Find(e, arguments, input1, input2, input3, input4, backend);
+            Option<(T1, T2, T3, T4)> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input1, input2, input3, input4, backend);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }
@@ -164,16 +167,16 @@ namespace ZenLib.SymbolicExecution
         /// <returns>A collection of inputs.</returns>
         public static IEnumerable<T1> GenerateInputsSage<T1, T2>(
             Zen<bool> precondition,
-            Func<Zen<bool>, Option<T1>> findFunction,
-            Func<T1, (T2, PathConstraint)> interpretFunction)
+            Func<Zen<bool>, Dictionary<long, object>, Option<T1>> findFunction,
+            Func<T1, (T2, PathConstraint, Dictionary<long, object>)> interpretFunction)
         {
-            var queue = new Queue<(Zen<bool>, int)>();
-            queue.Enqueue((precondition, 0));
+            var queue = new Queue<(Zen<bool>, Dictionary<long, object>, int)>();
+            queue.Enqueue((precondition, new Dictionary<long, object>(), 0));
 
             while (queue.Count > 0)
             {
-                var (expr, bound) = queue.Dequeue();
-                var example = findFunction(expr);
+                var (expr, environment, bound) = queue.Dequeue();
+                var example = findFunction(expr, environment);
 
                 if (!example.HasValue)
                 {
@@ -183,14 +186,14 @@ namespace ZenLib.SymbolicExecution
                 // return the next example.
                 yield return example.Value;
 
-                var (_, pathConstraint) = interpretFunction(example.Value);
+                var (_, pathConstraint, pathConstraintEnv) = interpretFunction(example.Value);
 
                 // generate all the children by negating some path constraint.
                 for (int j = bound; j < pathConstraint.Conjuncts.Count; j++)
                 {
                     var pc = pathConstraint.GetRange(0, j - 1);
                     var e = And(precondition, pc.GetExpr(), Not(pathConstraint.Conjuncts[j]));
-                    queue.Enqueue((e, j + 1));
+                    queue.Enqueue((e, pathConstraintEnv, j + 1));
                 }
             }
         }

--- a/ZenLib/ZenDataTypes/FSeq.cs
+++ b/ZenLib/ZenDataTypes/FSeq.cs
@@ -256,6 +256,30 @@ namespace ZenLib
         }
 
         /// <summary>
+        /// Get the head of the sequence.
+        /// </summary>
+        /// <param name="seqExpr">Zen sequence expression.</param>
+        /// <returns>The head, or the default value if the sequence is empty.</returns>
+        public static Zen<T> Head<T>(this Zen<FSeq<T>> seqExpr)
+        {
+            CommonUtilities.ValidateNotNull(seqExpr);
+
+            return seqExpr.Case(empty: Zen.Default<T>(), cons: (hd, tl) => hd);
+        }
+
+        /// <summary>
+        /// Get the tail of the sequence.
+        /// </summary>
+        /// <param name="seqExpr">Zen sequence expression.</param>
+        /// <returns>The tail, empty if the sequence is empty.</returns>
+        public static Zen<FSeq<T>> Tail<T>(this Zen<FSeq<T>> seqExpr)
+        {
+            CommonUtilities.ValidateNotNull(seqExpr);
+
+            return seqExpr.Case(empty: FSeq.Empty<T>(), cons: (hd, tl) => tl);
+        }
+
+        /// <summary>
         /// Get the length of the sequence.
         /// </summary>
         /// <param name="seqExpr">Zen sequence expression.</param>

--- a/ZenLib/ZenDataTypes/Option.cs
+++ b/ZenLib/ZenDataTypes/Option.cs
@@ -189,8 +189,7 @@ namespace ZenLib
         /// <returns>Zen value.</returns>
         public static Zen<Option<T>> Null<T>()
         {
-            var v = (Zen<T>)ReflectionUtilities.ApplyTypeVisitor(new DefaultTypeGenerator(), typeof(T), new Unit());
-            return Zen.Create<Option<T>>(("HasValue", False()), ("Value", v));
+            return Zen.Create<Option<T>>(("HasValue", False()), ("Value", Zen.Default<T>()));
         }
 
         /// <summary>

--- a/ZenLib/ZenDataTypes/Real.cs
+++ b/ZenLib/ZenDataTypes/Real.cs
@@ -14,14 +14,14 @@ namespace ZenLib
     public struct Real : IEquatable<Real>, IComparable<Real>
     {
         /// <summary>
-        /// The numerator.
+        /// The Real number numerator.
         /// </summary>
-        internal BigInteger Numerator;
+        public BigInteger Numerator;
 
         /// <summary>
-        /// The denominator.
+        /// The Real number denominator.
         /// </summary>
-        internal BigInteger Denominator;
+        public BigInteger Denominator;
 
         /// <summary>
         /// Convert a C# long to a Real.

--- a/ZenLib/ZenLanguage/Zen.cs
+++ b/ZenLib/ZenLanguage/Zen.cs
@@ -287,6 +287,15 @@ namespace ZenLib
         }
 
         /// <summary>
+        /// Gets the default value for a type as a zen value.
+        /// </summary>
+        /// <returns>The default expression.</returns>
+        public static Zen<T> Default<T>()
+        {
+            return (Zen<T>)ReflectionUtilities.ApplyTypeVisitor(new DefaultTypeGenerator(), typeof(T), new Unit());
+        }
+
+        /// <summary>
         /// The Zen value for false.
         /// </summary>
         /// <returns>Zen value.</returns>

--- a/ZenLib/ZenLanguage/Zen.cs
+++ b/ZenLib/ZenLanguage/Zen.cs
@@ -44,21 +44,12 @@ namespace ZenLib
         internal abstract TReturn Accept<TParam, TReturn>(IZenExprVisitor<TParam, TReturn> visitor, TParam parameter);
 
         /// <summary>
-        /// Simplify an expression recursively.
+        /// Format an expression to be more readable.
         /// </summary>
         /// <returns></returns>
         public string Format()
         {
             return CommonUtilities.RunWithLargeStack(() => new ZenFormatVisitor().Format(this));
-        }
-
-        /// <summary>
-        /// Simplify an expression recursively.
-        /// </summary>
-        /// <returns></returns>
-        public Zen<T> Simplify()
-        {
-            return CommonUtilities.RunWithLargeStack(() => this.Unroll());
         }
 
         /// <summary>
@@ -1506,6 +1497,202 @@ namespace ZenLib
         }
 
         /// <summary>
+        /// Evaluate a Zen function.
+        /// </summary>
+        /// <param name="f">The function.</param>
+        /// <returns>The value from running the function.</returns>
+        public static T Evaluate<T>(Func<Zen<T>> f)
+        {
+            return new ZenFunction<T>(f).Evaluate();
+        }
+
+        /// <summary>
+        /// Evaluate a Zen function.
+        /// </summary>
+        /// <param name="f">The function.</param>
+        /// <param name="input1">The input.</param>
+        /// <returns>The value from running the function.</returns>
+        public static T2 Evaluate<T1, T2>(Func<Zen<T1>, Zen<T2>> f, T1 input1)
+        {
+            return new ZenFunction<T1, T2>(f).Evaluate(input1);
+        }
+
+        /// <summary>
+        /// Evaluate a Zen function.
+        /// </summary>
+        /// <param name="f">The function.</param>
+        /// <param name="input1">The first input.</param>
+        /// <param name="input2">The second input.</param>
+        /// <returns>The value from running the function.</returns>
+        public static T3 Evaluate<T1, T2, T3>(Func<Zen<T1>, Zen<T2>, Zen<T3>> f, T1 input1, T2 input2)
+        {
+            return new ZenFunction<T1, T2, T3>(f).Evaluate(input1, input2);
+        }
+
+        /// <summary>
+        /// Evaluate a Zen function.
+        /// </summary>
+        /// <param name="f">The function.</param>
+        /// <param name="input1">The first input.</param>
+        /// <param name="input2">The second input.</param>
+        /// <param name="input3">The third input.</param>
+        /// <returns>The value from running the function.</returns>
+        public static T4 Evaluate<T1, T2, T3, T4>(Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>> f, T1 input1, T2 input2, T3 input3)
+        {
+            return new ZenFunction<T1, T2, T3, T4>(f).Evaluate(input1, input2, input3);
+        }
+
+        /// <summary>
+        /// Evaluate a Zen function.
+        /// </summary>
+        /// <param name="f">The function.</param>
+        /// <param name="input1">The first input.</param>
+        /// <param name="input2">The second input.</param>
+        /// <param name="input3">The third input.</param>
+        /// <param name="input4">The fourth input.</param>
+        /// <returns>The value from running the function.</returns>
+        public static T5 Evaluate<T1, T2, T3, T4, T5>(Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<T5>> f, T1 input1, T2 input2, T3 input3, T4 input4)
+        {
+            return new ZenFunction<T1, T2, T3, T4, T5>(f).Evaluate(input1, input2, input3, input4);
+        }
+
+        /// <summary>
+        /// Compile a Zen function to a C# function.
+        /// </summary>
+        /// <param name="f">The Zen function.</param>
+        /// <returns>The compiled C# function.</returns>
+        public static Func<T> Compile<T>(Func<Zen<T>> f)
+        {
+            var zf = new ZenFunction<T>(f);
+            zf.Compile();
+            return zf.Evaluate;
+        }
+
+        /// <summary>
+        /// Compile a Zen function to a C# function.
+        /// </summary>
+        /// <param name="f">The Zen function.</param>
+        /// <returns>The compiled C# function.</returns>
+        public static Func<T1, T2> Compile<T1, T2>(Func<Zen<T1>, Zen<T2>> f)
+        {
+            var zf = new ZenFunction<T1, T2>(f);
+            zf.Compile();
+            return zf.Evaluate;
+        }
+
+        /// <summary>
+        /// Compile a Zen function to a C# function.
+        /// </summary>
+        /// <param name="f">The Zen function.</param>
+        /// <returns>The compiled C# function.</returns>
+        public static Func<T1, T2, T3> Compile<T1, T2, T3>(Func<Zen<T1>, Zen<T2>, Zen<T3>> f)
+        {
+            var zf = new ZenFunction<T1, T2, T3>(f);
+            zf.Compile();
+            return zf.Evaluate;
+        }
+
+        /// <summary>
+        /// Compile a Zen function to a C# function.
+        /// </summary>
+        /// <param name="f">The Zen function.</param>
+        /// <returns>The compiled C# function.</returns>
+        public static Func<T1, T2, T3, T4> Compile<T1, T2, T3, T4>(Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>> f)
+        {
+            var zf = new ZenFunction<T1, T2, T3, T4>(f);
+            zf.Compile();
+            return zf.Evaluate;
+        }
+
+        /// <summary>
+        /// Compile a Zen function to a C# function.
+        /// </summary>
+        /// <param name="f">The Zen function.</param>
+        /// <returns>The compiled C# function.</returns>
+        public static Func<T1, T2, T3, T4, T5> Compile<T1, T2, T3, T4, T5>(Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<T5>> f)
+        {
+            var zf = new ZenFunction<T1, T2, T3, T4, T5>(f);
+            zf.Compile();
+            return zf.Evaluate;
+        }
+
+        /// <summary>
+        /// Generate inputs using symbolic execution.
+        /// </summary>
+        /// <param name="f">The Zen function.</param>
+        /// <param name="precondition">The precondition.</param>
+        /// <param name="depth">The maximum depth.</param>
+        /// <param name="exhaustiveDepth">Whether to exhastively enumerate FSeq depth.</param>
+        /// <param name="backend">The backend solver.</param>
+        /// <returns>The input values.</returns>
+        public static IEnumerable<T1> GenerateInputs<T1, T2>(
+            Func<Zen<T1>, Zen<T2>> f,
+            Func<Zen<T1>, Zen<bool>> precondition = null,
+            int depth = 5,
+            bool exhaustiveDepth = true,
+            Backend backend = Backend.Z3)
+        {
+            return new ZenFunction<T1, T2>(f).GenerateInputs(null, precondition, depth, exhaustiveDepth, backend);
+        }
+
+        /// <summary>
+        /// Generate inputs using symbolic execution.
+        /// </summary>
+        /// <param name="f">The Zen function.</param>
+        /// <param name="precondition">The precondition.</param>
+        /// <param name="depth">The maximum depth.</param>
+        /// <param name="exhaustiveDepth">Whether to exhastively enumerate FSeq depth.</param>
+        /// <param name="backend">The backend solver.</param>
+        /// <returns>The input values.</returns>
+        public static IEnumerable<(T1, T2)> GenerateInputs<T1, T2, T3>(
+            Func<Zen<T1>, Zen<T2>, Zen<T3>> f,
+            Func<Zen<T1>, Zen<T2>, Zen<bool>> precondition = null,
+            int depth = 5,
+            bool exhaustiveDepth = true,
+            Backend backend = Backend.Z3)
+        {
+            return new ZenFunction<T1, T2, T3>(f).GenerateInputs(null, null, precondition, depth, exhaustiveDepth, backend);
+        }
+
+        /// <summary>
+        /// Generate inputs using symbolic execution.
+        /// </summary>
+        /// <param name="f">The Zen function.</param>
+        /// <param name="precondition">The precondition.</param>
+        /// <param name="depth">The maximum depth.</param>
+        /// <param name="exhaustiveDepth">Whether to exhastively enumerate FSeq depth.</param>
+        /// <param name="backend">The backend solver.</param>
+        /// <returns>The input values.</returns>
+        public static IEnumerable<(T1, T2, T3)> GenerateInputs<T1, T2, T3, T4>(
+            Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>> f,
+            Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<bool>> precondition = null,
+            int depth = 5,
+            bool exhaustiveDepth = true,
+            Backend backend = Backend.Z3)
+        {
+            return new ZenFunction<T1, T2, T3, T4>(f).GenerateInputs(null, null, null, precondition, depth, exhaustiveDepth, backend);
+        }
+
+        /// <summary>
+        /// Generate inputs using symbolic execution.
+        /// </summary>
+        /// <param name="f">The Zen function.</param>
+        /// <param name="precondition">The precondition.</param>
+        /// <param name="depth">The maximum depth.</param>
+        /// <param name="exhaustiveDepth">Whether to exhastively enumerate FSeq depth.</param>
+        /// <param name="backend">The backend solver.</param>
+        /// <returns>The input values.</returns>
+        public static IEnumerable<(T1, T2, T3, T4)> GenerateInputs<T1, T2, T3, T4, T5>(
+            Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<T5>> f,
+            Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<bool>> precondition = null,
+            int depth = 5,
+            bool exhaustiveDepth = true,
+            Backend backend = Backend.Z3)
+        {
+            return new ZenFunction<T1, T2, T3, T4, T5>(f).GenerateInputs(null, null, null, null, precondition, depth, exhaustiveDepth, backend);
+        }
+
+        /// <summary>
         /// Evaluates a Zen expression given an assignment from arbitrary variable to C# object.
         /// </summary>
         /// <returns>Mapping from arbitrary expressions to C# objects.</returns>
@@ -1523,7 +1710,7 @@ namespace ZenLib
             }
 
             var solution = constraints.Solve();
-            var environment = new ExpressionEvaluatorEnvironment(solution.ArbitraryAssignment);
+            var environment = new ExpressionEvaluatorEnvironment(solution.VariableAssignment);
             var interpreter = new ExpressionEvaluator(false);
             return (T)interpreter.Evaluate(expr, environment);
         }
@@ -1533,7 +1720,51 @@ namespace ZenLib
         /// </summary>
         /// <param name="function">The zen function.</param>
         /// <param name="manager">An optional manager object.</param>
-        /// <returns>A transformer for the function.</returns>
+        /// <returns>A state set for the function.</returns>
+        public static StateSet<T> StateSet<T>(Func<Zen<T>, Zen<bool>> function, StateSetTransformerManager manager = null)
+        {
+            return Zen.StateSet<T>(new ZenFunction<T, bool>(function), manager);
+        }
+
+        /// <summary>
+        /// Gets the function as a state set.
+        /// </summary>
+        /// <param name="function">The zen function.</param>
+        /// <param name="manager">An optional manager object.</param>
+        /// <returns>A state set for the function.</returns>
+        public static StateSet<Pair<T1, T2>> StateSet<T1, T2>(Func<Zen<T1>, Zen<T2>, Zen<bool>> function, StateSetTransformerManager manager = null)
+        {
+            return new ZenFunction<T1, T2, bool>(function).StateSet(manager);
+        }
+
+        /// <summary>
+        /// Gets the function as a state set.
+        /// </summary>
+        /// <param name="function">The zen function.</param>
+        /// <param name="manager">An optional manager object.</param>
+        /// <returns>A state set for the function.</returns>
+        public static StateSet<Pair<T1, T2, T3>> StateSet<T1, T2, T3>(Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<bool>> function, StateSetTransformerManager manager = null)
+        {
+            return new ZenFunction<T1, T2, T3, bool>(function).StateSet(manager);
+        }
+
+        /// <summary>
+        /// Gets the function as a state set.
+        /// </summary>
+        /// <param name="function">The zen function.</param>
+        /// <param name="manager">An optional manager object.</param>
+        /// <returns>A state set for the function.</returns>
+        public static StateSet<Pair<T1, T2, T3, T4>> StateSet<T1, T2, T3, T4>(Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<bool>> function, StateSetTransformerManager manager = null)
+        {
+            return new ZenFunction<T1, T2, T3, T4, bool>(function).StateSet(manager);
+        }
+
+        /// <summary>
+        /// Gets the function as a state set.
+        /// </summary>
+        /// <param name="function">The zen function.</param>
+        /// <param name="manager">An optional manager object.</param>
+        /// <returns>A state set for the function.</returns>
         public static StateSet<T> StateSet<T>(this ZenFunction<T, bool> function, StateSetTransformerManager manager = null)
         {
             manager = StateSetTransformerFactory.GetOrDefaultManager(manager);
@@ -1554,7 +1785,7 @@ namespace ZenLib
         /// </summary>
         /// <param name="function">The zen function.</param>
         /// <param name="manager">An optional manager object.</param>
-        /// <returns>A transformer for the function.</returns>
+        /// <returns>A state set for the function.</returns>
         public static StateSet<Pair<T1, T2>> StateSet<T1, T2>(this ZenFunction<T1, T2, bool> function, StateSetTransformerManager manager = null)
         {
             manager = StateSetTransformerFactory.GetOrDefaultManager(manager);
@@ -1576,7 +1807,7 @@ namespace ZenLib
         /// </summary>
         /// <param name="function">The zen function.</param>
         /// <param name="manager">An optional manager object.</param>
-        /// <returns>A transformer for the function.</returns>
+        /// <returns>A state set for the function.</returns>
         public static StateSet<Pair<T1, T2, T3>> StateSet<T1, T2, T3>(this ZenFunction<T1, T2, T3, bool> function, StateSetTransformerManager manager = null)
         {
             manager = StateSetTransformerFactory.GetOrDefaultManager(manager);
@@ -1598,7 +1829,7 @@ namespace ZenLib
         /// </summary>
         /// <param name="function">The zen function.</param>
         /// <param name="manager">An optional manager object.</param>
-        /// <returns>A transformer for the function.</returns>
+        /// <returns>A state set for the function.</returns>
         public static StateSet<Pair<T1, T2, T3, T4>> StateSet<T1, T2, T3, T4>(this ZenFunction<T1, T2, T3, T4, bool> function, StateSetTransformerManager manager = null)
         {
             manager = StateSetTransformerFactory.GetOrDefaultManager(manager);
@@ -1613,6 +1844,60 @@ namespace ZenLib
             var result = CommonUtilities.RunWithLargeStack(() => StateSetTransformerFactory.CreateStateSet(f, manager));
             manager.StateSetCache.Add(key, result);
             return result;
+        }
+
+        /// <summary>
+        /// Gets the function as a transformer.
+        /// </summary>
+        /// <param name="function">The zen function.</param>
+        /// <param name="manager">An optional manager object.</param>
+        /// <returns>A transformer for the function.</returns>
+        public static StateSetTransformer<T1, T2> Transformer<T1, T2>(Func<Zen<T1>, Zen<T2>> function, StateSetTransformerManager manager = null)
+        {
+            return new ZenFunction<T1, T2>(function).Transformer(manager);
+        }
+
+        /// <summary>
+        /// Gets the function as a transformer.
+        /// </summary>
+        /// <param name="function">The zen function.</param>
+        /// <param name="manager">An optional manager object.</param>
+        /// <returns>A transformer for the function.</returns>
+        public static StateSetTransformer<Pair<T1, T2>, T3> Transformer<T1, T2, T3>(Func<Zen<T1>, Zen<T2>, Zen<T3>> function, StateSetTransformerManager manager = null)
+        {
+            return new ZenFunction<T1, T2, T3>(function).Transformer(manager);
+        }
+
+        /// <summary>
+        /// Gets the function as a transformer.
+        /// </summary>
+        /// <param name="function">The zen function.</param>
+        /// <param name="manager">An optional manager object.</param>
+        /// <returns>A transformer for the function.</returns>
+        public static StateSetTransformer<Pair<T1, T2, T3>, T4> Transformer<T1, T2, T3, T4>(Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>> function, StateSetTransformerManager manager = null)
+        {
+            return new ZenFunction<T1, T2, T3, T4>(function).Transformer(manager);
+        }
+
+        /// <summary>
+        /// Gets the function as a transformer.
+        /// </summary>
+        /// <param name="function">The zen function.</param>
+        /// <param name="manager">An optional manager object.</param>
+        /// <returns>A transformer for the function.</returns>
+        public static StateSetTransformer<Pair<T1, T2, T3, T4>, T5> Transformer<T1, T2, T3, T4, T5>(Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<T5>> function, StateSetTransformerManager manager = null)
+        {
+            return new ZenFunction<T1, T2, T3, T4, T5>(function).Transformer(manager);
+        }
+
+        /// <summary>
+        /// Flattens an expression recursively by removing list operations.
+        /// Note: this can explode the size of the expression.
+        /// </summary>
+        /// <returns>The resulting expression.</returns>
+        public static Zen<T> Flatten<T>(this Zen<T> expression)
+        {
+            return CommonUtilities.RunWithLargeStack(() => expression.Unroll());
         }
     }
 }

--- a/ZenLib/ZenLib.csproj
+++ b/ZenLib/ZenLib.csproj
@@ -10,7 +10,7 @@
     <RepositoryUrl>https://github.com/microsoft/Zen</RepositoryUrl>
     <Description>A library that simplifies building verification tools in .NET</Description>
     <PackageTags>zen zenlib modeling constraint solving verification smt solver binary decision diagrams diagram</PackageTags>
-    <Version>2.2.2</Version>
+    <Version>2.2.3</Version>
     <Platforms>AnyCPU;x64</Platforms>
     <PackageIcon>Zen-Icon.png</PackageIcon>
   </PropertyGroup>

--- a/ZenLib/ZenSolution.cs
+++ b/ZenLib/ZenSolution.cs
@@ -15,7 +15,7 @@ namespace ZenLib
         /// <summary>
         /// Assignment from arbitrary variables to C# values.
         /// </summary>
-        internal Dictionary<object, object> ArbitraryAssignment;
+        public Dictionary<object, object> VariableAssignment;
 
         /// <summary>
         /// Creates a new instance of the <see cref="ZenSolution"/> class.
@@ -23,7 +23,7 @@ namespace ZenLib
         /// <param name="arbitraryAssignment">The arbitrary assignment.</param>
         internal ZenSolution(Dictionary<object, object> arbitraryAssignment)
         {
-            this.ArbitraryAssignment = arbitraryAssignment;
+            this.VariableAssignment = arbitraryAssignment;
         }
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace ZenLib
         /// <returns>True if the solution exists.</returns>
         public bool IsSatisfiable()
         {
-            return ArbitraryAssignment != null;
+            return VariableAssignment != null;
         }
 
         /// <summary>
@@ -43,12 +43,12 @@ namespace ZenLib
         /// <returns>The C# value associated with the expression.</returns>
         public T Get<T>(Zen<T> expr)
         {
-            if (this.ArbitraryAssignment != null && this.ArbitraryAssignment.TryGetValue(expr, out var value))
+            if (this.VariableAssignment != null && this.VariableAssignment.TryGetValue(expr, out var value))
             {
                 return (T)value;
             }
 
-            var interpreterEnv = new ExpressionEvaluatorEnvironment(this.ArbitraryAssignment);
+            var interpreterEnv = new ExpressionEvaluatorEnvironment(this.VariableAssignment);
             var interpreter = new ExpressionEvaluator(false);
             return (T)interpreter.Evaluate(expr, interpreterEnv);
         }


### PR DESCRIPTION
Previously the symbolic execution engine would have to first unfold the expression to remove list case expressions. This could lead to an exponential blowup in the term size since it unfolded all paths proactively.

This changes the implementation to avoid this unfolding by carrying the symbolic context along in the interpreter.