### PR TITLE
puts all the hashconsing into a single place

### DIFF
--- a/ZenLib.Bench/Program.cs
+++ b/ZenLib.Bench/Program.cs
@@ -4,15 +4,12 @@
 
 namespace ZenLibBench
 {
-    using System;
-    using System.Linq;
     using ZenLib;
-    using ZenLib.TransitionSystem;
  
     /// <summary>
     /// Run a collection of benchmarks for Zen.
     /// </summary>
-    class Program
+    public class Program
     {
         /// <summary>
         /// Main entry point.

--- a/ZenLib.Tests/FlyweightTests.cs
+++ b/ZenLib.Tests/FlyweightTests.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HashConsTableTests.cs" company="Microsoft">
+﻿// <copyright file="FlyweightTests.cs" company="Microsoft">
 // Copyright (c) Microsoft. All rights reserved.
 // </copyright>
 
@@ -13,7 +13,7 @@ namespace ZenLib.Tests
     /// </summary>
     [TestClass]
     [ExcludeFromCodeCoverage]
-    public class HashConsTableTests
+    public class FlyweightTests
     {
         /// <summary>
         /// Test that Zen ids are working.

--- a/ZenLib.Tests/HashConsTableTests.cs
+++ b/ZenLib.Tests/HashConsTableTests.cs
@@ -36,7 +36,7 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestInsertion()
         {
-            var ht = new HashConsTable<int, object>();
+            var ht = new Flyweight<int, object>();
             Check(ht);
         }
 
@@ -46,7 +46,7 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestGarbageCollection()
         {
-            var ht = new HashConsTable<int, object>();
+            var ht = new Flyweight<int, object>();
             Check(ht);
             GC.Collect();
             Check(ht);
@@ -56,7 +56,7 @@ namespace ZenLib.Tests
         /// Checks insertion into the hash cons table.
         /// </summary>
         /// <param name="ht">The table to use.</param>
-        private void Check(HashConsTable<int, object> ht)
+        private void Check(Flyweight<int, object> ht)
         {
             Assert.IsTrue(ht.GetOrAdd(1, 1, (v) => v, out var _));
             Assert.IsTrue(ht.GetOrAdd(2, 2, (v) => v, out var _));
@@ -69,7 +69,7 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestInsertMany()
         {
-            var ht = new HashConsTable<int, object>();
+            var ht = new Flyweight<int, object>();
 
             for (int i = 0; i < 1000; i++)
             {

--- a/ZenLib.Tests/SimplifierTests.cs
+++ b/ZenLib.Tests/SimplifierTests.cs
@@ -35,18 +35,6 @@ namespace ZenLib.Tests
         }
 
         /// <summary>
-        /// Test hash consing of terms.
-        /// </summary>
-        [TestMethod]
-        public void TestHashCons()
-        {
-            Assert.IsTrue(ReferenceEquals(~Constant<int>(10), ~Constant<int>(10)));
-            Assert.IsTrue(ReferenceEquals(Constant<int>(10) - Constant<int>(10), Constant<int>(10) - Constant<int>(10)));
-            Assert.IsTrue(ReferenceEquals(Constant<int>(10) * Constant<int>(10), Constant<int>(10) * Constant<int>(10)));
-            Assert.IsTrue(ReferenceEquals(Option.Create<int>(1), Option.Create<int>(1)));
-        }
-
-        /// <summary>
         /// Simplify and with constants.
         /// </summary>
         [TestMethod]
@@ -351,92 +339,6 @@ namespace ZenLib.Tests
         }
 
         /// <summary>
-        /// Test hash consing of concat.
-        /// </summary>
-        [TestMethod]
-        public void TestConcatHashCons()
-        {
-            var s = Arbitrary<string>();
-            var e1 = s + "ll";
-            var e2 = s + "ll";
-            var e3 = s + "lll";
-            Assert.IsTrue(ReferenceEquals(e1, e2));
-            Assert.IsFalse(ReferenceEquals(e1, e3));
-        }
-
-        /// <summary>
-        /// Test hash consing of containment.
-        /// </summary>
-        [TestMethod]
-        public void TestContainsHashCons()
-        {
-            var s = Arbitrary<string>();
-            var e1 = s.Contains("ll");
-            var e2 = s.Contains("ll");
-            var e3 = s.EndsWith("ll");
-            Assert.IsTrue(ReferenceEquals(e1, e2));
-            Assert.IsFalse(ReferenceEquals(e1, e3));
-        }
-
-        /// <summary>
-        /// Test hash consing of replacement.
-        /// </summary>
-        [TestMethod]
-        public void TestReplaceHashCons()
-        {
-            var s = Arbitrary<string>();
-            var e1 = s.ReplaceFirst("xx", "yy");
-            var e2 = s.ReplaceFirst("xx", "yy");
-            var e3 = s.ReplaceFirst("xx", "zz");
-            Assert.IsTrue(ReferenceEquals(e1, e2));
-            Assert.IsFalse(ReferenceEquals(e1, e3));
-        }
-
-        /// <summary>
-        /// Test hash consing of substring.
-        /// </summary>
-        [TestMethod]
-        public void TestSubstringHashCons()
-        {
-            var s = Arbitrary<string>();
-            var e1 = s.Slice(new BigInteger(0), new BigInteger(1));
-            var e2 = s.Slice(new BigInteger(0), new BigInteger(1));
-            var e3 = s.Slice(new BigInteger(0), new BigInteger(2));
-            var e4 = s.Slice(new BigInteger(1), new BigInteger(1));
-            Assert.IsTrue(ReferenceEquals(e1, e2));
-            Assert.IsFalse(ReferenceEquals(e1, e3));
-            Assert.IsFalse(ReferenceEquals(e1, e4));
-        }
-
-        /// <summary>
-        /// Test hash consing of length.
-        /// </summary>
-        [TestMethod]
-        public void TestLengthHashCons()
-        {
-            var e1 = Zen.Length("abc");
-            var e2 = Zen.Length("abc");
-            var e3 = Zen.Length("ab");
-            Assert.IsTrue(ReferenceEquals(e1, e2));
-            Assert.IsFalse(ReferenceEquals(e1, e3));
-        }
-
-        /// <summary>
-        /// Test hash consing of indexof.
-        /// </summary>
-        [TestMethod]
-        public void TestIndexOfHashCons()
-        {
-            var e1 = Zen.IndexOf("abc", "a", new BigInteger(0));
-            var e2 = Zen.IndexOf("abc", "a", new BigInteger(0));
-            var e3 = Zen.IndexOf("abc", "a", new BigInteger(1));
-            var e4 = Zen.IndexOf("abc", "b", new BigInteger(0));
-            Assert.IsTrue(ReferenceEquals(e1, e2));
-            Assert.IsFalse(ReferenceEquals(e1, e3));
-            Assert.IsFalse(ReferenceEquals(e1, e4));
-        }
-
-        /// <summary>
         /// Simplify if conditions.
         /// </summary>
         [TestMethod]
@@ -709,11 +611,109 @@ namespace ZenLib.Tests
         /// Exception thrown since implicit conversion won't work with object fields.
         /// </summary>
         [TestMethod]
-        public void TestHashconsingWorksForCreate()
+        public void TestFlyweightWorksForCreate()
         {
             var x = Create<Object2>(("Field1", Constant(0)), ("Field2", Constant(0)));
             var y = Create<Object2>(("Field2", Constant(0)), ("Field1", Constant(0)));
             Assert.AreEqual(x, y);
+        }
+
+        /// <summary>
+        /// Test hash consing of terms.
+        /// </summary>
+        [TestMethod]
+        public void TestFlyweight()
+        {
+            Assert.IsTrue(ReferenceEquals(~Constant<int>(10), ~Constant<int>(10)));
+            Assert.IsTrue(ReferenceEquals(Constant<int>(10) - Constant<int>(10), Constant<int>(10) - Constant<int>(10)));
+            Assert.IsTrue(ReferenceEquals(Constant<int>(10) * Constant<int>(10), Constant<int>(10) * Constant<int>(10)));
+            Assert.IsTrue(ReferenceEquals(Option.Create<int>(1), Option.Create<int>(1)));
+        }
+
+        /// <summary>
+        /// Test hash consing of concat.
+        /// </summary>
+        [TestMethod]
+        public void TestConcatFlyweight()
+        {
+            var s = Arbitrary<string>();
+            var e1 = s + "ll";
+            var e2 = s + "ll";
+            var e3 = s + "lll";
+            Assert.IsTrue(ReferenceEquals(e1, e2));
+            Assert.IsFalse(ReferenceEquals(e1, e3));
+        }
+
+        /// <summary>
+        /// Test hash consing of containment.
+        /// </summary>
+        [TestMethod]
+        public void TestContainsFlyweight()
+        {
+            var s = Arbitrary<string>();
+            var e1 = s.Contains("ll");
+            var e2 = s.Contains("ll");
+            var e3 = s.EndsWith("ll");
+            Assert.IsTrue(ReferenceEquals(e1, e2));
+            Assert.IsFalse(ReferenceEquals(e1, e3));
+        }
+
+        /// <summary>
+        /// Test hash consing of replacement.
+        /// </summary>
+        [TestMethod]
+        public void TestReplaceFlyweight()
+        {
+            var s = Arbitrary<string>();
+            var e1 = s.ReplaceFirst("xx", "yy");
+            var e2 = s.ReplaceFirst("xx", "yy");
+            var e3 = s.ReplaceFirst("xx", "zz");
+            Assert.IsTrue(ReferenceEquals(e1, e2));
+            Assert.IsFalse(ReferenceEquals(e1, e3));
+        }
+
+        /// <summary>
+        /// Test hash consing of substring.
+        /// </summary>
+        [TestMethod]
+        public void TestSubstringFlyweight()
+        {
+            var s = Arbitrary<string>();
+            var e1 = s.Slice(new BigInteger(0), new BigInteger(1));
+            var e2 = s.Slice(new BigInteger(0), new BigInteger(1));
+            var e3 = s.Slice(new BigInteger(0), new BigInteger(2));
+            var e4 = s.Slice(new BigInteger(1), new BigInteger(1));
+            Assert.IsTrue(ReferenceEquals(e1, e2));
+            Assert.IsFalse(ReferenceEquals(e1, e3));
+            Assert.IsFalse(ReferenceEquals(e1, e4));
+        }
+
+        /// <summary>
+        /// Test hash consing of length.
+        /// </summary>
+        [TestMethod]
+        public void TestLengthFlyweight()
+        {
+            var e1 = Zen.Length("abc");
+            var e2 = Zen.Length("abc");
+            var e3 = Zen.Length("ab");
+            Assert.IsTrue(ReferenceEquals(e1, e2));
+            Assert.IsFalse(ReferenceEquals(e1, e3));
+        }
+
+        /// <summary>
+        /// Test hash consing of indexof.
+        /// </summary>
+        [TestMethod]
+        public void TestIndexOfFlyweight()
+        {
+            var e1 = Zen.IndexOf("abc", "a", new BigInteger(0));
+            var e2 = Zen.IndexOf("abc", "a", new BigInteger(0));
+            var e3 = Zen.IndexOf("abc", "a", new BigInteger(1));
+            var e4 = Zen.IndexOf("abc", "b", new BigInteger(0));
+            Assert.IsTrue(ReferenceEquals(e1, e2));
+            Assert.IsFalse(ReferenceEquals(e1, e3));
+            Assert.IsFalse(ReferenceEquals(e1, e4));
         }
     }
 }

--- a/ZenLib/Common/Flyweight.cs
+++ b/ZenLib/Common/Flyweight.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="HashConsTable.cs" company="Microsoft">
+﻿// <copyright file="Flyweight.cs" company="Microsoft">
 // Copyright (c) Microsoft. All rights reserved.
 // </copyright>
 
@@ -8,11 +8,11 @@ namespace ZenLib
     using System.Collections.Generic;
 
     /// <summary>
-    /// A hash cons table that is able to reclaim memory.
+    /// A flyweight table that is able to reclaim memory.
     /// It uses weak references to Zen values and overrides
     /// values that have been garbage collected when inserting.
     /// </summary>
-    internal sealed class HashConsTable<TKey, TValue> where TValue : class
+    internal sealed class Flyweight<TKey, TValue> where TValue : class
     {
         /// <summary>
         /// Lock object for the hash cons table.
@@ -20,7 +20,7 @@ namespace ZenLib
         private object lockObj = new object();
 
         /// <summary>
-        /// The table of hash consed elements.
+        /// The table of flyweight elements.
         /// </summary>
         private Dictionary<TKey, WeakReference<TValue>> table = new Dictionary<TKey, WeakReference<TValue>>();
 
@@ -28,7 +28,7 @@ namespace ZenLib
         /// Creates a new HashConsTable.
         /// </summary>
         /// <param name="comparer">An optional comparer.</param>
-        public HashConsTable(IEqualityComparer<TKey> comparer = null)
+        public Flyweight(IEqualityComparer<TKey> comparer = null)
         {
             if (comparer == null)
             {

--- a/ZenLib/Common/Flyweight.cs
+++ b/ZenLib/Common/Flyweight.cs
@@ -25,7 +25,7 @@ namespace ZenLib
         private Dictionary<TKey, WeakReference<TValue>> table = new Dictionary<TKey, WeakReference<TValue>>();
 
         /// <summary>
-        /// Creates a new HashConsTable.
+        /// Creates a new instance of the <see cref="Flyweight{TKey, TValue}"/> class.
         /// </summary>
         /// <param name="comparer">An optional comparer.</param>
         public Flyweight(IEqualityComparer<TKey> comparer = null)

--- a/ZenLib/Common/ReflectionUtilities.cs
+++ b/ZenLib/Common/ReflectionUtilities.cs
@@ -8,7 +8,6 @@ namespace ZenLib
     using System.Collections.Generic;
     using System.Numerics;
     using System.Reflection;
-    using ZenLib.ZenLanguage;
 
     /// <summary>
     /// A collection of helper functions for manipulating Zen
@@ -25,11 +24,6 @@ namespace ZenLib
         /// The type of byte sequences values.
         /// </summary>
         public readonly static Type UnicodeSequenceType = typeof(Seq<char>);
-
-        /* /// <summary>
-        /// The type of finite string values.
-        /// </summary>
-        public readonly static Type FiniteStringType = typeof(FString); */
 
         /// <summary>
         /// The type of set unit values.

--- a/ZenLib/Language/Ast/ZenApplyExpr.cs
+++ b/ZenLib/Language/Ast/ZenApplyExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -12,11 +11,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenApplyExpr<TSrc, TDst> : Zen<TDst>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(ZenLambda<TSrc, TDst>, Zen<TSrc>), Zen<TDst>> createFunc = (v) => Simplify(v.Item1, v.Item2);
-
         /// <summary>
         /// Hash cons table for ZenApplyExpr.
         /// </summary>
@@ -35,12 +29,11 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a new ZenApplyExpr.
         /// </summary>
-        /// <param name="lambda">The lambda expression.</param>
-        /// <param name="parameterExpr">The parameter expression.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns>The new expr.</returns>
-        private static Zen<TDst> Simplify(ZenLambda<TSrc, TDst> lambda, Zen<TSrc> parameterExpr)
+        private static Zen<TDst> Simplify((ZenLambda<TSrc, TDst> lambda, Zen<TSrc> parameterExpr) args)
         {
-            return new ZenApplyExpr<TSrc, TDst>(lambda, parameterExpr);
+            return new ZenApplyExpr<TSrc, TDst>(args.lambda, args.parameterExpr);
         }
 
         /// <summary>
@@ -55,7 +48,7 @@ namespace ZenLib
             Contract.AssertNotNull(parameterExpr);
 
             var key = (lambda, parameterExpr.Id);
-            hashConsTable.GetOrAdd(key, (lambda, parameterExpr), createFunc, out var value);
+            hashConsTable.GetOrAdd(key, (lambda, parameterExpr), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenApplyExpr.cs
+++ b/ZenLib/Language/Ast/ZenApplyExpr.cs
@@ -12,11 +12,6 @@ namespace ZenLib
     internal sealed class ZenApplyExpr<TSrc, TDst> : Zen<TDst>
     {
         /// <summary>
-        /// Hash cons table for ZenApplyExpr.
-        /// </summary>
-        private static HashConsTable<(object, long), Zen<TDst>> hashConsTable = new HashConsTable<(object, long), Zen<TDst>>();
-
-        /// <summary>
         /// Gets the first expression.
         /// </summary>
         internal ZenLambda<TSrc, TDst> Lambda { get; }
@@ -48,7 +43,8 @@ namespace ZenLib
             Contract.AssertNotNull(parameterExpr);
 
             var key = (lambda, parameterExpr.Id);
-            hashConsTable.GetOrAdd(key, (lambda, parameterExpr), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenApplyExpr<TSrc, TDst>, (object, long), Zen<TDst>>.Flyweight;
+            flyweight.GetOrAdd(key, (lambda, parameterExpr), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenArithBinopExpr.cs
+++ b/ZenLib/Language/Ast/ZenArithBinopExpr.cs
@@ -49,11 +49,6 @@ namespace ZenLib
         };
 
         /// <summary>
-        /// Hash cons table for ZenArithBinopExpr.
-        /// </summary>
-        private static HashConsTable<(long, long, int), Zen<T>> hashConsTable = new HashConsTable<(long, long, int), Zen<T>>();
-
-        /// <summary>
         /// Gets the first expression.
         /// </summary>
         internal Zen<T> Expr1 { get; }
@@ -207,7 +202,8 @@ namespace ZenLib
             }
 
             var key = (expr1.Id, expr2.Id, (int)op);
-            hashConsTable.GetOrAdd(key, (expr1, expr2, op), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenArithBinopExpr<T>, (long, long, int), Zen<T>>.Flyweight;
+            flyweight.GetOrAdd(key, (expr1, expr2, op), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenArithBinopExpr.cs
+++ b/ZenLib/Language/Ast/ZenArithBinopExpr.cs
@@ -14,11 +14,6 @@ namespace ZenLib
     internal sealed class ZenArithBinopExpr<T> : Zen<T>
     {
         /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<T>, Zen<T>, ArithmeticOp), Zen<T>> createFunc = (v) => Simplify(v.Item1, v.Item2, v.Item3);
-
-        /// <summary>
         /// The operation strings for integer operations.
         /// </summary>
         private static string[] opStrings = new string[] { "+", "-", "*" };
@@ -76,121 +71,119 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a new ZenArithBinopExpr.
         /// </summary>
-        /// <param name="e1">The first expr.</param>
-        /// <param name="e2">The second expr.</param>
-        /// <param name="op">The operation.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns>The new expr.</returns>
-        private static Zen<T> Simplify(Zen<T> e1, Zen<T> e2, ArithmeticOp op)
+        private static Zen<T> Simplify((Zen<T> e1, Zen<T> e2, ArithmeticOp op) args)
         {
             if (typeof(T) == typeof(BigInteger))
             {
                 // constant folding for BigInteger.
-                if (e1 is ZenConstantExpr<BigInteger> be1 && e2 is ZenConstantExpr<BigInteger> be2)
+                if (args.e1 is ZenConstantExpr<BigInteger> be1 && args.e2 is ZenConstantExpr<BigInteger> be2)
                 {
-                    return (Zen<T>)(object)ZenConstantExpr<BigInteger>.Create(constantBigIntFuncs[(int)op](be1.Value, be2.Value));
+                    return (Zen<T>)(object)ZenConstantExpr<BigInteger>.Create(constantBigIntFuncs[(int)args.op](be1.Value, be2.Value));
                 }
 
                 // arithmetic identities.
-                switch (op)
+                switch (args.op)
                 {
                     case ArithmeticOp.Addition:
-                        if (e1 is ZenConstantExpr<BigInteger> a && a.Value == BigInteger.Zero)
-                            return e2;
-                        if (e2 is ZenConstantExpr<BigInteger> b && b.Value == BigInteger.Zero)
-                            return e1;
+                        if (args.e1 is ZenConstantExpr<BigInteger> a && a.Value == BigInteger.Zero)
+                            return args.e2;
+                        if (args.e2 is ZenConstantExpr<BigInteger> b && b.Value == BigInteger.Zero)
+                            return args.e1;
                         break;
 
                     case ArithmeticOp.Subtraction:
-                        if (e2 is ZenConstantExpr<BigInteger> e && e.Value == BigInteger.Zero)
-                            return e1;
+                        if (args.e2 is ZenConstantExpr<BigInteger> e && e.Value == BigInteger.Zero)
+                            return args.e1;
                         break;
 
                     case ArithmeticOp.Multiplication:
-                        if (e1 is ZenConstantExpr<BigInteger> g && g.Value == BigInteger.Zero)
+                        if (args.e1 is ZenConstantExpr<BigInteger> g && g.Value == BigInteger.Zero)
                             return (Zen<T>)(object)Zen.Constant(BigInteger.Zero);
-                        if (e2 is ZenConstantExpr<BigInteger> h && h.Value == BigInteger.Zero)
+                        if (args.e2 is ZenConstantExpr<BigInteger> h && h.Value == BigInteger.Zero)
                             return (Zen<T>)(object)Zen.Constant(BigInteger.Zero);
-                        if (e1 is ZenConstantExpr<BigInteger> i && i.Value == BigInteger.One)
-                            return e2;
-                        if (e2 is ZenConstantExpr<BigInteger> j && j.Value == BigInteger.One)
-                            return e1;
+                        if (args.e1 is ZenConstantExpr<BigInteger> i && i.Value == BigInteger.One)
+                            return args.e2;
+                        if (args.e2 is ZenConstantExpr<BigInteger> j && j.Value == BigInteger.One)
+                            return args.e1;
                         break;
                 }
             }
             else if (typeof(T) == typeof(Real))
             {
                 // constant folding for Real.
-                if (e1 is ZenConstantExpr<Real> re1 && e2 is ZenConstantExpr<Real> re2)
+                if (args.e1 is ZenConstantExpr<Real> re1 && args.e2 is ZenConstantExpr<Real> re2)
                 {
-                    return (Zen<T>)(object)ZenConstantExpr<Real>.Create(constantRealFuncs[(int)op](re1.Value, re2.Value));
+                    return (Zen<T>)(object)ZenConstantExpr<Real>.Create(constantRealFuncs[(int)args.op](re1.Value, re2.Value));
                 }
 
                 // arithmetic identities.
-                switch (op)
+                switch (args.op)
                 {
                     case ArithmeticOp.Addition:
-                        if (e1 is ZenConstantExpr<Real> c && c.Value == new Real(0))
-                            return e2;
-                        if (e2 is ZenConstantExpr<Real> d && d.Value == new Real(0))
-                            return e1;
+                        if (args.e1 is ZenConstantExpr<Real> c && c.Value == new Real(0))
+                            return args.e2;
+                        if (args.e2 is ZenConstantExpr<Real> d && d.Value == new Real(0))
+                            return args.e1;
                         break;
 
                     case ArithmeticOp.Subtraction:
-                        if (e2 is ZenConstantExpr<Real> f && f.Value == new Real(0))
-                            return e1;
+                        if (args.e2 is ZenConstantExpr<Real> f && f.Value == new Real(0))
+                            return args.e1;
                         break;
 
                     case ArithmeticOp.Multiplication:
-                        if (e1 is ZenConstantExpr<Real> k && k.Value == new Real(0))
+                        if (args.e1 is ZenConstantExpr<Real> k && k.Value == new Real(0))
                             return (Zen<T>)(object)Zen.Constant(new Real(0));
-                        if (e2 is ZenConstantExpr<Real> l && l.Value == new Real(0))
+                        if (args.e2 is ZenConstantExpr<Real> l && l.Value == new Real(0))
                             return (Zen<T>)(object)Zen.Constant(new Real(0));
-                        if (e1 is ZenConstantExpr<Real> m && m.Value == new Real(1))
-                            return e2;
-                        if (e2 is ZenConstantExpr<Real> n && n.Value == new Real(1))
-                            return e1;
+                        if (args.e1 is ZenConstantExpr<Real> m && m.Value == new Real(1))
+                            return args.e2;
+                        if (args.e2 is ZenConstantExpr<Real> n && n.Value == new Real(1))
+                            return args.e1;
                         break;
                 }
             }
             else
             {
                 // constant folding for other types.
-                var x = ReflectionUtilities.GetConstantIntegerValue(e1);
-                var y = ReflectionUtilities.GetConstantIntegerValue(e2);
+                var x = ReflectionUtilities.GetConstantIntegerValue(args.e1);
+                var y = ReflectionUtilities.GetConstantIntegerValue(args.e2);
 
                 if (x.HasValue && y.HasValue)
                 {
-                    var f = constantFuncs[(int)op];
+                    var f = constantFuncs[(int)args.op];
                     return ReflectionUtilities.CreateConstantIntegerValue<T>(f(x.Value, y.Value));
                 }
 
                 // arithmetic identities.
-                switch (op)
+                switch (args.op)
                 {
                     case ArithmeticOp.Addition:
                         if (x.HasValue && x.Value == 0)
-                            return e2;
+                            return args.e2;
                         if (y.HasValue && y.Value == 0)
-                            return e1;
+                            return args.e1;
                         break;
 
                     case ArithmeticOp.Subtraction:
                         if (y.HasValue && y.Value == 0)
-                            return e1;
+                            return args.e1;
                         break;
 
                     case ArithmeticOp.Multiplication:
                         if ((x.HasValue && x.Value == 0) || (y.HasValue && y.Value == 0))
                             return ReflectionUtilities.CreateConstantIntegerValue<T>(0);
                         if (x.HasValue && x.Value == 1)
-                            return e2;
+                            return args.e2;
                         if (y.HasValue && y.Value == 1)
-                            return e1;
+                            return args.e1;
                         break;
                 }
             }
 
-            return new ZenArithBinopExpr<T>(e1, e2, op);
+            return new ZenArithBinopExpr<T>(args.e1, args.e2, args.op);
         }
 
         /// <summary>
@@ -214,7 +207,7 @@ namespace ZenLib
             }
 
             var key = (expr1.Id, expr2.Id, (int)op);
-            hashConsTable.GetOrAdd(key, (expr1, expr2, op), createFunc, out var value);
+            hashConsTable.GetOrAdd(key, (expr1, expr2, op), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenArithComparisonExpr.cs
+++ b/ZenLib/Language/Ast/ZenArithComparisonExpr.cs
@@ -14,11 +14,6 @@ namespace ZenLib
     internal sealed class ZenArithComparisonExpr<T> : Zen<bool>
     {
         /// <summary>
-        /// Hash cons table for ZenComparisonExpr.
-        /// </summary>
-        private static HashConsTable<(long, long, int), Zen<bool>> hashConsTable = new HashConsTable<(long, long, int), Zen<bool>>();
-
-        /// <summary>
         /// The strings for different comparison operations.
         /// </summary>
         private string[] opStrings = new string[] { ">=", "<=", ">", "<" };
@@ -128,7 +123,8 @@ namespace ZenLib
             Contract.Assert(ReflectionUtilities.IsArithmeticType(typeof(T)));
 
             var key = (expr1.Id, expr2.Id, (int)comparisonType);
-            hashConsTable.GetOrAdd(key, (expr1, expr2, comparisonType), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenArithComparisonExpr<T>, (long, long, int), Zen<bool>>.Flyweight;
+            flyweight.GetOrAdd(key, (expr1, expr2, comparisonType), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenAstCache.cs
+++ b/ZenLib/Language/Ast/ZenAstCache.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="ZenAstCache.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace ZenLib
+{
+    /// <summary>
+    /// A cache for Zen ast expressions.
+    /// </summary>
+    internal static class ZenAstCache<TObj, TKey, TValue> where TValue : class
+    {
+        /// <summary>
+        /// A flyweight object that stores the expressions for each key.
+        /// The object type TObj is to ensure that different flyweights are used
+        /// for each AST node type. This ensures better parallelism.
+        /// </summary>
+        internal static Flyweight<TKey, TValue> Flyweight = new Flyweight<TKey, TValue>();
+    }
+}

--- a/ZenLib/Language/Ast/ZenAstCache.cs
+++ b/ZenLib/Language/Ast/ZenAstCache.cs
@@ -4,6 +4,9 @@
 
 namespace ZenLib
 {
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+
     /// <summary>
     /// A cache for Zen ast expressions.
     /// </summary>
@@ -15,5 +18,57 @@ namespace ZenLib
         /// for each AST node type. This ensures better parallelism.
         /// </summary>
         internal static Flyweight<TKey, TValue> Flyweight = new Flyweight<TKey, TValue>();
+
+        /// <summary>
+        /// Hash cons table for ZenCreateObjectExpr.
+        /// </summary>
+        internal static Flyweight<TKey[], TValue> FlyweightArray = new Flyweight<TKey[], TValue>(new ArrayComparer());
+
+        /// <summary>
+        /// Custom array comparer for ensuring hash consing uniqueness.
+        /// </summary>
+        [ExcludeFromCodeCoverage]
+        private class ArrayComparer : IEqualityComparer<TKey[]>
+        {
+            /// <summary>
+            /// Equality for key arrays.
+            /// </summary>
+            /// <param name="a1">The first array.</param>
+            /// <param name="a2">The second array.</param>
+            /// <returns>True or false.</returns>
+            public bool Equals(TKey[] a1, TKey[] a2)
+            {
+                if (a1.Length != a2.Length)
+                {
+                    return false;
+                }
+
+                for (int i = 0; i < a1.Length; i++)
+                {
+                    if (!a1[i].Equals(a2[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+
+            /// <summary>
+            /// Hash code for the keys.
+            /// </summary>
+            /// <param name="array">The array of keys.</param>
+            /// <returns>An integer.</returns>
+            public int GetHashCode(TKey[] array)
+            {
+                int result = 31;
+                for (int i = 0; i < array.Length; i++)
+                {
+                    result = result * 7 + array[i].GetHashCode();
+                }
+
+                return result;
+            }
+        }
     }
 }

--- a/ZenLib/Language/Ast/ZenBitwiseBinopExpr.cs
+++ b/ZenLib/Language/Ast/ZenBitwiseBinopExpr.cs
@@ -28,11 +28,6 @@ namespace ZenLib
         };
 
         /// <summary>
-        /// Hash cons table for ZenIntegerBinopExpr.
-        /// </summary>
-        private static HashConsTable<(long, long, int), Zen<T>> hashConsTable = new HashConsTable<(long, long, int), Zen<T>>();
-
-        /// <summary>
         /// Gets the first expression.
         /// </summary>
         internal Zen<T> Expr1 { get; }
@@ -81,7 +76,8 @@ namespace ZenLib
 
             var type = typeof(T);
             var key = (expr1.Id, expr2.Id, (int)op);
-            hashConsTable.GetOrAdd(key, (expr1, expr2, op), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenBitwiseBinopExpr<T>, (long, long, int), Zen<T>>.Flyweight;
+            flyweight.GetOrAdd(key, (expr1, expr2, op), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenBitwiseBinopExpr.cs
+++ b/ZenLib/Language/Ast/ZenBitwiseBinopExpr.cs
@@ -13,11 +13,6 @@ namespace ZenLib
     internal sealed class ZenBitwiseBinopExpr<T> : Zen<T>
     {
         /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<T>, Zen<T>, BitwiseOp), Zen<T>> createFunc = (v) => Simplify(v.Item1, v.Item2, v.Item3);
-
-        /// <summary>
         /// The operation strings for integer operations.
         /// </summary>
         private static string[] opStrings = new string[] { "&", "|", "^" };
@@ -55,22 +50,20 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a new ZenBitwiseBinopExpr.
         /// </summary>
-        /// <param name="e1">The first expr.</param>
-        /// <param name="e2">The second expr.</param>
-        /// <param name="op">The integer operation.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns>The new expr.</returns>
-        private static Zen<T> Simplify(Zen<T> e1, Zen<T> e2, BitwiseOp op)
+        private static Zen<T> Simplify((Zen<T> e1, Zen<T> e2, BitwiseOp op) args)
         {
-            var x = ReflectionUtilities.GetConstantIntegerValue(e1);
-            var y = ReflectionUtilities.GetConstantIntegerValue(e2);
+            var x = ReflectionUtilities.GetConstantIntegerValue(args.e1);
+            var y = ReflectionUtilities.GetConstantIntegerValue(args.e2);
 
             if (x.HasValue && y.HasValue)
             {
-                var f = constantFuncs[(int)op];
+                var f = constantFuncs[(int)args.op];
                 return ReflectionUtilities.CreateConstantIntegerValue<T>(f(x.Value, y.Value));
             }
 
-            return new ZenBitwiseBinopExpr<T>(e1, e2, op);
+            return new ZenBitwiseBinopExpr<T>(args.e1, args.e2, args.op);
         }
 
         /// <summary>
@@ -88,7 +81,7 @@ namespace ZenLib
 
             var type = typeof(T);
             var key = (expr1.Id, expr2.Id, (int)op);
-            hashConsTable.GetOrAdd(key, (expr1, expr2, op), createFunc, out var value);
+            hashConsTable.GetOrAdd(key, (expr1, expr2, op), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenBitwiseNotExpr.cs
+++ b/ZenLib/Language/Ast/ZenBitwiseNotExpr.cs
@@ -12,11 +12,6 @@ namespace ZenLib
     internal sealed class ZenBitwiseNotExpr<T> : Zen<T>
     {
         /// <summary>
-        /// Hash cons table for ZenBitwiseNot expr.
-        /// </summary>
-        private static HashConsTable<long, Zen<T>> hashConsTable = new HashConsTable<long, Zen<T>>();
-
-        /// <summary>
         /// Gets the expression.
         /// </summary>
         internal Zen<T> Expr { get; }
@@ -53,7 +48,8 @@ namespace ZenLib
             Contract.AssertNotNull(expr);
             Contract.Assert(ReflectionUtilities.IsFiniteIntegerType(typeof(T)));
 
-            hashConsTable.GetOrAdd(expr.Id, expr, Simplify, out var value);
+            var flyweight = ZenAstCache<ZenBitwiseNotExpr<T>, long, Zen<T>>.Flyweight;
+            flyweight.GetOrAdd(expr.Id, expr, Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenCastExpr.cs
+++ b/ZenLib/Language/Ast/ZenCastExpr.cs
@@ -12,11 +12,6 @@ namespace ZenLib
     internal sealed class ZenCastExpr<TSource, TTarget> : Zen<TTarget>
     {
         /// <summary>
-        /// Hash cons table for ZenCastExpr.
-        /// </summary>
-        private static HashConsTable<long, Zen<TTarget>> hashConsTable = new HashConsTable<long, Zen<TTarget>>();
-
-        /// <summary>
         /// Gets the source expr.
         /// </summary>
         public Zen<TSource> SourceExpr { get; }
@@ -38,7 +33,8 @@ namespace ZenLib
             Contract.AssertNotNull(sourceExpr);
             Contract.Assert(CommonUtilities.IsSafeCast(typeof(TSource), typeof(TTarget)), "Invalid cast");
 
-            hashConsTable.GetOrAdd(sourceExpr.Id, sourceExpr, Simplify, out var v);
+            var flyweight = ZenAstCache<ZenCastExpr<TSource, TTarget>, long, Zen<TTarget>>.Flyweight;
+            flyweight.GetOrAdd(sourceExpr.Id, sourceExpr, Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenCastExpr.cs
+++ b/ZenLib/Language/Ast/ZenCastExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -12,11 +11,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenCastExpr<TSource, TTarget> : Zen<TTarget>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<Zen<TSource>, Zen<TTarget>> createFunc = (v) => new ZenCastExpr<TSource, TTarget>(v);
-
         /// <summary>
         /// Hash cons table for ZenCastExpr.
         /// </summary>
@@ -28,6 +22,13 @@ namespace ZenLib
         public Zen<TSource> SourceExpr { get; }
 
         /// <summary>
+        /// Simplify and create a new ZenCastExpr expr.
+        /// </summary>
+        /// <param name="e">The expr to cast.</param>
+        /// <returns>The new expr.</returns>
+        private static Zen<TTarget> Simplify(Zen<TSource> e) => new ZenCastExpr<TSource, TTarget>(e);
+
+        /// <summary>
         /// Create a new ZenCastExpr.
         /// </summary>
         /// <param name="sourceExpr">The source expr.</param>
@@ -37,7 +38,7 @@ namespace ZenLib
             Contract.AssertNotNull(sourceExpr);
             Contract.Assert(CommonUtilities.IsSafeCast(typeof(TSource), typeof(TTarget)), "Invalid cast");
 
-            hashConsTable.GetOrAdd(sourceExpr.Id, sourceExpr, createFunc, out var v);
+            hashConsTable.GetOrAdd(sourceExpr.Id, sourceExpr, Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenConstMapGetExpr.cs
+++ b/ZenLib/Language/Ast/ZenConstMapGetExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -12,12 +11,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenConstMapGetExpr<TKey, TValue> : Zen<TValue>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<CMap<TKey, TValue>>, TKey), Zen<TValue>> createFunc = (v) =>
-            Simplify(v.Item1, v.Item2);
-
         /// <summary>
         /// Hash cons table for ZenConstMapGetExpr.
         /// </summary>
@@ -37,17 +30,16 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a new ZenConstMapGetExpr.
         /// </summary>
-        /// <param name="map">The map expr.</param>
-        /// <param name="key">The key.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns>The new Zen expr.</returns>
-        private static Zen<TValue> Simplify(Zen<CMap<TKey, TValue>> map, TKey key)
+        private static Zen<TValue> Simplify((Zen<CMap<TKey, TValue>> map, TKey key) args)
         {
-            if (map is ZenConstMapSetExpr<TKey, TValue> e2 && e2.Key.Equals(key))
+            if (args.map is ZenConstMapSetExpr<TKey, TValue> e2 && e2.Key.Equals(args.key))
             {
                 return e2.ValueExpr;
             }
 
-            return new ZenConstMapGetExpr<TKey, TValue>(map, key);
+            return new ZenConstMapGetExpr<TKey, TValue>(args.map, args.key);
         }
 
         /// <summary>
@@ -62,7 +54,7 @@ namespace ZenLib
             Contract.AssertNotNull(key);
 
             var k = (mapExpr.Id, key);
-            hashConsTable.GetOrAdd(k, (mapExpr, key), createFunc, out var v);
+            hashConsTable.GetOrAdd(k, (mapExpr, key), Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenConstMapGetExpr.cs
+++ b/ZenLib/Language/Ast/ZenConstMapGetExpr.cs
@@ -12,12 +12,6 @@ namespace ZenLib
     internal sealed class ZenConstMapGetExpr<TKey, TValue> : Zen<TValue>
     {
         /// <summary>
-        /// Hash cons table for ZenConstMapGetExpr.
-        /// </summary>
-        private static HashConsTable<(long, TKey), Zen<TValue>> hashConsTable =
-            new HashConsTable<(long, TKey), Zen<TValue>>();
-
-        /// <summary>
         /// Gets the map expr.
         /// </summary>
         public Zen<CMap<TKey, TValue>> MapExpr { get; }
@@ -54,7 +48,8 @@ namespace ZenLib
             Contract.AssertNotNull(key);
 
             var k = (mapExpr.Id, key);
-            hashConsTable.GetOrAdd(k, (mapExpr, key), Simplify, out var v);
+            var flyweight = ZenAstCache<ZenConstMapGetExpr<TKey, TValue>, (long, TKey), Zen<TValue>>.Flyweight;
+            flyweight.GetOrAdd(k, (mapExpr, key), Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenConstMapSetExpr.cs
+++ b/ZenLib/Language/Ast/ZenConstMapSetExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -12,11 +11,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenConstMapSetExpr<TKey, TValue> : Zen<CMap<TKey, TValue>>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<CMap<TKey, TValue>>, TKey, Zen<TValue>), Zen<CMap<TKey, TValue>>> createFunc = (v) => Simplify(v.Item1, v.Item2, v.Item3);
-
         /// <summary>
         /// Hash cons table for ZenConstMapSetExpr.
         /// </summary>
@@ -40,18 +34,16 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a new ZenMapSetExpr.
         /// </summary>
-        /// <param name="map">The map expr.</param>
-        /// <param name="key">The key expr.</param>
-        /// <param name="value">The value expr.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns>The new Zen expr.</returns>
-        private static Zen<CMap<TKey, TValue>> Simplify(Zen<CMap<TKey, TValue>> map, TKey key, Zen<TValue> value)
+        private static Zen<CMap<TKey, TValue>> Simplify((Zen<CMap<TKey, TValue>> map, TKey key, Zen<TValue> value) args)
         {
-            if (map is ZenConstMapSetExpr<TKey, TValue> e1 && e1.Key.Equals(key))
+            if (args.map is ZenConstMapSetExpr<TKey, TValue> e1 && e1.Key.Equals(args.key))
             {
-                return Create(e1.MapExpr, key, value);
+                return Create(e1.MapExpr, args.key, args.value);
             }
 
-            return new ZenConstMapSetExpr<TKey, TValue>(map, key, value);
+            return new ZenConstMapSetExpr<TKey, TValue>(args.map, args.key, args.value);
         }
 
         /// <summary>
@@ -68,7 +60,7 @@ namespace ZenLib
             Contract.AssertNotNull(value);
 
             var k = (mapExpr.Id, key, value.Id);
-            hashConsTable.GetOrAdd(k, (mapExpr, key, value), createFunc, out var v);
+            hashConsTable.GetOrAdd(k, (mapExpr, key, value), Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenConstMapSetExpr.cs
+++ b/ZenLib/Language/Ast/ZenConstMapSetExpr.cs
@@ -12,11 +12,6 @@ namespace ZenLib
     internal sealed class ZenConstMapSetExpr<TKey, TValue> : Zen<CMap<TKey, TValue>>
     {
         /// <summary>
-        /// Hash cons table for ZenConstMapSetExpr.
-        /// </summary>
-        private static HashConsTable<(long, TKey, long), Zen<CMap<TKey, TValue>>> hashConsTable = new HashConsTable<(long, TKey, long), Zen<CMap<TKey, TValue>>>();
-
-        /// <summary>
         /// Gets the map expr.
         /// </summary>
         public Zen<CMap<TKey, TValue>> MapExpr { get; }
@@ -60,7 +55,8 @@ namespace ZenLib
             Contract.AssertNotNull(value);
 
             var k = (mapExpr.Id, key, value.Id);
-            hashConsTable.GetOrAdd(k, (mapExpr, key, value), Simplify, out var v);
+            var flyweight = ZenAstCache<ZenConstMapSetExpr<TKey, TValue>, (long, TKey, long), Zen<CMap<TKey, TValue>>>.Flyweight;
+            flyweight.GetOrAdd(k, (mapExpr, key, value), Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenConstantExpr.cs
+++ b/ZenLib/Language/Ast/ZenConstantExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -12,11 +11,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenConstantExpr<T> : Zen<T>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<T, Zen<T>> createFunc = (v) => new ZenConstantExpr<T>(v);
-
         /// <summary>
         /// Hash cons table.
         /// </summary>
@@ -28,13 +22,20 @@ namespace ZenLib
         internal T Value { get; }
 
         /// <summary>
+        /// Simplify and create a new ZenBitwiseNot expr.
+        /// </summary>
+        /// <param name="c">The constant.</param>
+        /// <returns>The new expr.</returns>
+        private static Zen<T> Simplify(T c) => new ZenConstantExpr<T>(c);
+
+        /// <summary>
         /// Create a new ZenConstantExpr.
         /// </summary>
         /// <param name="value">The constant value.</param>
         /// <returns>The Zen expr.</returns>
         public static Zen<T> Create(T value)
         {
-            hashConsTable.GetOrAdd(value, value, createFunc, out var v);
+            hashConsTable.GetOrAdd(value, value, Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenConstantExpr.cs
+++ b/ZenLib/Language/Ast/ZenConstantExpr.cs
@@ -12,11 +12,6 @@ namespace ZenLib
     internal sealed class ZenConstantExpr<T> : Zen<T>
     {
         /// <summary>
-        /// Hash cons table.
-        /// </summary>
-        private static HashConsTable<T, Zen<T>> hashConsTable = new HashConsTable<T, Zen<T>>();
-
-        /// <summary>
         /// Gets the value.
         /// </summary>
         internal T Value { get; }
@@ -35,7 +30,8 @@ namespace ZenLib
         /// <returns>The Zen expr.</returns>
         public static Zen<T> Create(T value)
         {
-            hashConsTable.GetOrAdd(value, value, Simplify, out var v);
+            var flyweight = ZenAstCache<ZenConstantExpr<T>, T, Zen<T>>.Flyweight;
+            flyweight.GetOrAdd(value, value, Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenCreateObjectExpr.cs
+++ b/ZenLib/Language/Ast/ZenCreateObjectExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Text;
@@ -15,11 +14,6 @@ namespace ZenLib
     internal sealed class ZenCreateObjectExpr<TObject> : Zen<TObject>
     {
         /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(string, object)[], Zen<TObject>> createFunc = (v) => new ZenCreateObjectExpr<TObject>(v);
-
-        /// <summary>
         /// Hash cons table for ZenCreateObjectExpr.
         /// </summary>
         private static HashConsTable<(string, long)[], Zen<TObject>> hashConsTable = new HashConsTable<(string, long)[], Zen<TObject>>(new ArrayComparer());
@@ -28,6 +22,13 @@ namespace ZenLib
         /// The fields of the object.
         /// </summary>
         public SortedDictionary<string, object> Fields { get; }
+
+        /// <summary>
+        /// Simplify and create a new ZenCreateObjectExpr.
+        /// </summary>
+        /// <param name="fields">The fields.</param>
+        /// <returns>The new expr.</returns>
+        private static Zen<TObject> Simplify((string, object)[] fields) => new ZenCreateObjectExpr<TObject>(fields);
 
         /// <summary>
         /// Creates a new ZenCreateObjectExpr.
@@ -58,7 +59,7 @@ namespace ZenLib
                 fieldIds[i] = (f.Item1, id);
             }
 
-            hashConsTable.GetOrAdd(fieldIds, fields, createFunc, out var value);
+            hashConsTable.GetOrAdd(fieldIds, fields, Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenCreateObjectExpr.cs
+++ b/ZenLib/Language/Ast/ZenCreateObjectExpr.cs
@@ -16,7 +16,7 @@ namespace ZenLib
         /// <summary>
         /// Hash cons table for ZenCreateObjectExpr.
         /// </summary>
-        private static HashConsTable<(string, long)[], Zen<TObject>> hashConsTable = new HashConsTable<(string, long)[], Zen<TObject>>(new ArrayComparer());
+        private static Flyweight<(string, long)[], Zen<TObject>> hashConsTable = new Flyweight<(string, long)[], Zen<TObject>>(new ArrayComparer());
 
         /// <summary>
         /// The fields of the object.

--- a/ZenLib/Language/Ast/ZenCreateObjectExpr.cs
+++ b/ZenLib/Language/Ast/ZenCreateObjectExpr.cs
@@ -14,11 +14,6 @@ namespace ZenLib
     internal sealed class ZenCreateObjectExpr<TObject> : Zen<TObject>
     {
         /// <summary>
-        /// Hash cons table for ZenCreateObjectExpr.
-        /// </summary>
-        private static Flyweight<(string, long)[], Zen<TObject>> hashConsTable = new Flyweight<(string, long)[], Zen<TObject>>(new ArrayComparer());
-
-        /// <summary>
         /// The fields of the object.
         /// </summary>
         public SortedDictionary<string, object> Fields { get; }
@@ -59,7 +54,8 @@ namespace ZenLib
                 fieldIds[i] = (f.Item1, id);
             }
 
-            hashConsTable.GetOrAdd(fieldIds, fields, Simplify, out var value);
+            var flyweight = ZenAstCache<ZenCreateObjectExpr<TObject>, (string, long), Zen<TObject>>.FlyweightArray;
+            flyweight.GetOrAdd(fieldIds, fields, Simplify, out var value);
             return value;
         }
 
@@ -117,43 +113,6 @@ namespace ZenLib
         internal override void Accept(ZenExprActionVisitor visitor)
         {
             visitor.Visit(this);
-        }
-
-        /// <summary>
-        /// Custom array comparer for ensuring hash consing uniqueness.
-        /// </summary>
-        [ExcludeFromCodeCoverage]
-        private class ArrayComparer : IEqualityComparer<(string, long)[]>
-        {
-            public bool Equals((string, long)[] a1, (string, long)[] a2)
-            {
-                if (a1.Length != a2.Length)
-                {
-                    return false;
-                }
-
-                for (int i = 0; i < a1.Length; i++)
-                {
-                    if (a1[i] != a2[i])
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
-
-            public int GetHashCode((string, long)[] array)
-            {
-                int result = 31;
-                for (int i = 0; i < array.Length; i++)
-                {
-                    var (s, o) = array[i];
-                    result = result * 7 + s.GetHashCode() + o.GetHashCode();
-                }
-
-                return result;
-            }
         }
     }
 }

--- a/ZenLib/Language/Ast/ZenEqualityExpr.cs
+++ b/ZenLib/Language/Ast/ZenEqualityExpr.cs
@@ -13,11 +13,6 @@ namespace ZenLib
     internal sealed class ZenEqualityExpr<T> : Zen<bool>
     {
         /// <summary>
-        /// Hash cons table for ZenEqualityExpr.
-        /// </summary>
-        private static HashConsTable<(long, long), Zen<bool>> hashConsTable = new HashConsTable<(long, long), Zen<bool>>();
-
-        /// <summary>
         /// Gets the first expression.
         /// </summary>
         internal Zen<T> Expr1 { get; }
@@ -76,7 +71,8 @@ namespace ZenLib
             Contract.AssertNotNull(expr2);
 
             var key = (expr1.Id, expr2.Id);
-            hashConsTable.GetOrAdd(key, (expr1, expr2), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenEqualityExpr<T>, (long, long), Zen<bool>>.Flyweight;
+            flyweight.GetOrAdd(key, (expr1, expr2), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenEqualityExpr.cs
+++ b/ZenLib/Language/Ast/ZenEqualityExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Numerics;
 
@@ -13,11 +12,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenEqualityExpr<T> : Zen<bool>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<T>, Zen<T>), Zen<bool>> createFunc = (v) => Simplify(v.Item1, v.Item2);
-
         /// <summary>
         /// Hash cons table for ZenEqualityExpr.
         /// </summary>
@@ -36,39 +30,38 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a ZenEqualityExpr.
         /// </summary>
-        /// <param name="e1">The first expr.</param>
-        /// <param name="e2">The second expr.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns>A new ZenEqualityExpr.</returns>
-        private static Zen<bool> Simplify(Zen<T> e1, Zen<T> e2)
+        private static Zen<bool> Simplify((Zen<T> e1, Zen<T> e2) args)
         {
-            if (e1 is ZenConstantExpr<BigInteger> be1 && e2 is ZenConstantExpr<BigInteger> be2)
+            if (args.e1 is ZenConstantExpr<BigInteger> be1 && args.e2 is ZenConstantExpr<BigInteger> be2)
             {
                 return Zen.Constant(be1.Value == be2.Value);
             }
 
-            if (e1 is ZenConstantExpr<ulong> ue1 && e2 is ZenConstantExpr<ulong> ue2)
+            if (args.e1 is ZenConstantExpr<ulong> ue1 && args.e2 is ZenConstantExpr<ulong> ue2)
             {
                 return Zen.Constant(ue1.Value == ue2.Value);
             }
 
-            if (e1 is ZenConstantExpr<bool> b1)
+            if (args.e1 is ZenConstantExpr<bool> b1)
             {
-                return b1.Value ? (Zen<bool>)(object)e2 : Zen.Not((Zen<bool>)(object)e2);
+                return b1.Value ? (Zen<bool>)(object)args.e2 : Zen.Not((Zen<bool>)(object)args.e2);
             }
 
-            if (e2 is ZenConstantExpr<bool> b2)
+            if (args.e2 is ZenConstantExpr<bool> b2)
             {
-                return b2.Value ? (Zen<bool>)(object)e1 : Zen.Not((Zen<bool>)(object)e1);
+                return b2.Value ? (Zen<bool>)(object)args.e1 : Zen.Not((Zen<bool>)(object)args.e1);
             }
 
-            var x = ReflectionUtilities.GetConstantIntegerValue(e1);
-            var y = ReflectionUtilities.GetConstantIntegerValue(e2);
+            var x = ReflectionUtilities.GetConstantIntegerValue(args.e1);
+            var y = ReflectionUtilities.GetConstantIntegerValue(args.e2);
             if (x.HasValue && y.HasValue)
             {
                 return Zen.Constant(x.Value == y.Value);
             }
 
-            return new ZenEqualityExpr<T>(e1, e2);
+            return new ZenEqualityExpr<T>(args.e1, args.e2);
         }
 
         /// <summary>
@@ -83,7 +76,7 @@ namespace ZenLib
             Contract.AssertNotNull(expr2);
 
             var key = (expr1.Id, expr2.Id);
-            hashConsTable.GetOrAdd(key, (expr1, expr2), createFunc, out var value);
+            hashConsTable.GetOrAdd(key, (expr1, expr2), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenFSeqAddFrontExpr.cs
+++ b/ZenLib/Language/Ast/ZenFSeqAddFrontExpr.cs
@@ -12,11 +12,6 @@ namespace ZenLib
     internal sealed class ZenFSeqAddFrontExpr<T> : Zen<FSeq<T>>
     {
         /// <summary>
-        /// Hash cons table for ZenListAddFrontExpr.
-        /// </summary>
-        private static HashConsTable<(long, long), Zen<FSeq<T>>> hashConsTable = new HashConsTable<(long, long), Zen<FSeq<T>>>();
-
-        /// <summary>
         /// Gets the list expr.
         /// </summary>
         public Zen<FSeq<T>> ListExpr { get; }
@@ -45,7 +40,8 @@ namespace ZenLib
             Contract.AssertNotNull(element);
 
             var key = (expr.Id, element.Id);
-            hashConsTable.GetOrAdd(key, (expr, element), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenFSeqAddFrontExpr<T>, (long, long), Zen<FSeq<T>>>.Flyweight;
+            flyweight.GetOrAdd(key, (expr, element), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenFSeqAddFrontExpr.cs
+++ b/ZenLib/Language/Ast/ZenFSeqAddFrontExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -13,14 +12,9 @@ namespace ZenLib
     internal sealed class ZenFSeqAddFrontExpr<T> : Zen<FSeq<T>>
     {
         /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<FSeq<T>>, Zen<Option<T>>), ZenFSeqAddFrontExpr<T>> createFunc = (v) => new ZenFSeqAddFrontExpr<T>(v.Item1, v.Item2);
-
-        /// <summary>
         /// Hash cons table for ZenListAddFrontExpr.
         /// </summary>
-        private static HashConsTable<(long, long), ZenFSeqAddFrontExpr<T>> hashConsTable = new HashConsTable<(long, long), ZenFSeqAddFrontExpr<T>>();
+        private static HashConsTable<(long, long), Zen<FSeq<T>>> hashConsTable = new HashConsTable<(long, long), Zen<FSeq<T>>>();
 
         /// <summary>
         /// Gets the list expr.
@@ -33,18 +27,25 @@ namespace ZenLib
         public Zen<Option<T>> ElementExpr { get; }
 
         /// <summary>
+        /// Simplify and create a ZenFSeqAddFrontExpr.
+        /// </summary>
+        /// <param name="args">The arguments.</param>
+        /// <returns>A new expr.</returns>
+        private static Zen<FSeq<T>> Simplify((Zen<FSeq<T>> e1, Zen<Option<T>> e2) args) => new ZenFSeqAddFrontExpr<T>(args.e1, args.e2);
+
+        /// <summary>
         /// Create a new ZenListAddFrontExpr.
         /// </summary>
         /// <param name="expr">The list expr.</param>
         /// <param name="element">The element expr.</param>
         /// <returns>The new expr.</returns>
-        public static ZenFSeqAddFrontExpr<T> Create(Zen<FSeq<T>> expr, Zen<Option<T>> element)
+        public static Zen<FSeq<T>> Create(Zen<FSeq<T>> expr, Zen<Option<T>> element)
         {
             Contract.AssertNotNull(expr);
             Contract.AssertNotNull(element);
 
             var key = (expr.Id, element.Id);
-            hashConsTable.GetOrAdd(key, (expr, element), createFunc, out var value);
+            hashConsTable.GetOrAdd(key, (expr, element), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenFSeqCaseExpr.cs
+++ b/ZenLib/Language/Ast/ZenFSeqCaseExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>

--- a/ZenLib/Language/Ast/ZenFSeqCaseExpr.cs
+++ b/ZenLib/Language/Ast/ZenFSeqCaseExpr.cs
@@ -29,23 +29,21 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a new ZenListCaseExpr.
         /// </summary>
-        /// <param name="e">The list expr.</param>
-        /// <param name="emptyCase">The empty case.</param>
-        /// <param name="consCase">The cons case.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns></returns>
-        private static Zen<TResult> Simplify(Zen<FSeq<T>> e, Zen<TResult> emptyCase, ZenLambda<Pair<Option<T>, FSeq<T>>, TResult> consCase)
+        private static Zen<TResult> Simplify((Zen<FSeq<T>> e, Zen<TResult> empty, ZenLambda<Pair<Option<T>, FSeq<T>>, TResult> cons) args)
         {
-            if (e is ZenConstantExpr<FSeq<T>> ce && ce.Value.IsEmpty())
+            if (args.e is ZenConstantExpr<FSeq<T>> ce && ce.Value.IsEmpty())
             {
-                return emptyCase;
+                return args.empty;
             }
 
-            if (e is ZenFSeqAddFrontExpr<T> l2)
+            if (args.e is ZenFSeqAddFrontExpr<T> l2)
             {
-                return consCase.Function(Pair.Create(l2.ElementExpr, l2.ListExpr));
+                return args.cons.Function(Pair.Create(l2.ElementExpr, l2.ListExpr));
             }
 
-            return new ZenFSeqCaseExpr<T, TResult>(e, emptyCase, consCase);
+            return new ZenFSeqCaseExpr<T, TResult>(args.e, args.empty, args.cons);
         }
 
         /// <summary>
@@ -64,7 +62,10 @@ namespace ZenLib
             Contract.AssertNotNull(empty);
             Contract.AssertNotNull(cons);
 
-            return Simplify(listExpr, empty, cons);
+            var key = (listExpr.Id, empty.Id, cons);
+            var flyweight = ZenAstCache<ZenFSeqCaseExpr<T, TResult>, (long, long, object), Zen<TResult>>.Flyweight;
+            flyweight.GetOrAdd(key, (listExpr, empty, cons), Simplify, out var value);
+            return value;
         }
 
         /// <summary>

--- a/ZenLib/Language/Ast/ZenGetFieldExpr.cs
+++ b/ZenLib/Language/Ast/ZenGetFieldExpr.cs
@@ -12,11 +12,6 @@ namespace ZenLib
     internal sealed class ZenGetFieldExpr<T1, T2> : Zen<T2>
     {
         /// <summary>
-        /// Hash cons table for ZenGetFieldExpr.
-        /// </summary>
-        private static HashConsTable<(long, string), Zen<T2>> hashConsTable = new HashConsTable<(long, string), Zen<T2>>();
-
-        /// <summary>
         /// Gets the expression.
         /// </summary>
         public Zen<T1> Expr { get; }
@@ -69,7 +64,8 @@ namespace ZenLib
             Contract.AssertFieldOrProperty(typeof(T1), typeof(T2), fieldName);
 
             var key = (expr.Id, fieldName);
-            hashConsTable.GetOrAdd(key, (expr, fieldName), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenGetFieldExpr<T1, T2>, (long, string), Zen<T2>>.Flyweight;
+            flyweight.GetOrAdd(key, (expr, fieldName), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenIfExpr.cs
+++ b/ZenLib/Language/Ast/ZenIfExpr.cs
@@ -12,11 +12,6 @@ namespace ZenLib
     internal sealed class ZenIfExpr<T> : Zen<T>
     {
         /// <summary>
-        /// Hash cons table for ZenIfExpr.
-        /// </summary>
-        private static HashConsTable<(long, long, long), Zen<T>> hashConsTable = new HashConsTable<(long, long, long), Zen<T>>();
-
-        /// <summary>
         /// Gets the guard expression.
         /// </summary>
         internal Zen<bool> GuardExpr { get; }
@@ -92,7 +87,8 @@ namespace ZenLib
             Contract.AssertNotNull(falseExpr);
 
             var key = (guardExpr.Id, trueExpr.Id, falseExpr.Id);
-            hashConsTable.GetOrAdd(key, (guardExpr, trueExpr, falseExpr), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenIfExpr<T>, (long, long, long), Zen<T>>.Flyweight;
+            flyweight.GetOrAdd(key, (guardExpr, trueExpr, falseExpr), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenLogicalBinopExpr.cs
+++ b/ZenLib/Language/Ast/ZenLogicalBinopExpr.cs
@@ -12,11 +12,6 @@ namespace ZenLib
     internal sealed class ZenLogicalBinopExpr : Zen<bool>
     {
         /// <summary>
-        /// Hash cons table for And terms.
-        /// </summary>
-        private static HashConsTable<(long, long, int), Zen<bool>> hashConsTable = new HashConsTable<(long, long, int), Zen<bool>>();
-
-        /// <summary>
         /// Gets the first expression.
         /// </summary>
         internal Zen<bool> Expr1 { get; }
@@ -85,7 +80,8 @@ namespace ZenLib
             Contract.AssertNotNull(expr2);
 
             var key = (expr1.Id, expr2.Id, (int)op);
-            hashConsTable.GetOrAdd(key, (expr1, expr2, op), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenLogicalBinopExpr, (long, long, int), Zen<bool>>.Flyweight;
+            flyweight.GetOrAdd(key, (expr1, expr2, op), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenLogicalBinopExpr.cs
+++ b/ZenLib/Language/Ast/ZenLogicalBinopExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -12,11 +11,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenLogicalBinopExpr : Zen<bool>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<bool>, Zen<bool>, LogicalOp), Zen<bool>> createFunc = (v) => Simplify(v.Item1, v.Item2, v.Item3);
-
         /// <summary>
         /// Hash cons table for And terms.
         /// </summary>
@@ -40,44 +34,42 @@ namespace ZenLib
         /// <summary>
         /// Simplify a new ZenAndExpr.
         /// </summary>
-        /// <param name="e1">The first expr.</param>
-        /// <param name="e2">The second expr.</param>
-        /// <param name="op">The operation.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns>The new Zen expr.</returns>
-        private static Zen<bool> Simplify(Zen<bool> e1, Zen<bool> e2, LogicalOp op)
+        private static Zen<bool> Simplify((Zen<bool> e1, Zen<bool> e2, LogicalOp op) args)
         {
-            if (ReferenceEquals(e1, e2))
+            if (ReferenceEquals(args.e1, args.e2))
             {
-                return e1;
+                return args.e1;
             }
 
-            if (op == LogicalOp.And)
+            if (args.op == LogicalOp.And)
             {
-                if (e1 is ZenConstantExpr<bool> x)
+                if (args.e1 is ZenConstantExpr<bool> x)
                 {
-                    return (x.Value ? e2 : e1);
+                    return (x.Value ? args.e2 : args.e1);
                 }
 
-                if (e2 is ZenConstantExpr<bool> y)
+                if (args.e2 is ZenConstantExpr<bool> y)
                 {
-                    return (y.Value ? e1 : e2);
+                    return (y.Value ? args.e1 : args.e2);
                 }
             }
             else
             {
-                Contract.Assert(op == LogicalOp.Or);
-                if (e1 is ZenConstantExpr<bool> x)
+                Contract.Assert(args.op == LogicalOp.Or);
+                if (args.e1 is ZenConstantExpr<bool> x)
                 {
-                    return (x.Value ? e1 : e2);
+                    return (x.Value ? args.e1 : args.e2);
                 }
 
-                if (e2 is ZenConstantExpr<bool> y)
+                if (args.e2 is ZenConstantExpr<bool> y)
                 {
-                    return (y.Value ? e2 : e1);
+                    return (y.Value ? args.e2 : args.e1);
                 }
             }
 
-            return new ZenLogicalBinopExpr(e1, e2, op);
+            return new ZenLogicalBinopExpr(args.e1, args.e2, args.op);
         }
 
         /// <summary>
@@ -93,7 +85,7 @@ namespace ZenLib
             Contract.AssertNotNull(expr2);
 
             var key = (expr1.Id, expr2.Id, (int)op);
-            hashConsTable.GetOrAdd(key, (expr1, expr2, op), createFunc, out var value);
+            hashConsTable.GetOrAdd(key, (expr1, expr2, op), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenMapCombineExpr.cs
+++ b/ZenLib/Language/Ast/ZenMapCombineExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -12,12 +11,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenMapCombineExpr<TKey> : Zen<Map<TKey, SetUnit>>
     {
-        /// <summary>
-        /// Hash cons table for ZenMapCombineExpr.
-        /// </summary>
-        private static HashConsTable<(long, long, int), Zen<Map<TKey, SetUnit>>> hashConsTable =
-            new HashConsTable<(long, long, int), Zen<Map<TKey, SetUnit>>>();
-
         /// <summary>
         /// Gets the first map expr.
         /// </summary>
@@ -123,7 +116,8 @@ namespace ZenLib
             Contract.AssertNotNull(mapExpr2);
 
             var k = (mapExpr1.Id, mapExpr2.Id, (int)combineType);
-            hashConsTable.GetOrAdd(k, (mapExpr1, mapExpr2, combineType), Simplify, out var v);
+            var flyweight = ZenAstCache<ZenMapCombineExpr<TKey>, (long, long, int), Zen<Map<TKey, SetUnit>>>.Flyweight;
+            flyweight.GetOrAdd(k, (mapExpr1, mapExpr2, combineType), Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenMapCombineExpr.cs
+++ b/ZenLib/Language/Ast/ZenMapCombineExpr.cs
@@ -13,12 +13,6 @@ namespace ZenLib
     internal sealed class ZenMapCombineExpr<TKey> : Zen<Map<TKey, SetUnit>>
     {
         /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<Map<TKey, SetUnit>>, Zen<Map<TKey, SetUnit>>, CombineType), Zen<Map<TKey, SetUnit>>> createFunc = (v) =>
-            Simplify(v.Item1, v.Item2, v.Item3);
-
-        /// <summary>
         /// Hash cons table for ZenMapCombineExpr.
         /// </summary>
         private static HashConsTable<(long, long, int), Zen<Map<TKey, SetUnit>>> hashConsTable =
@@ -42,79 +36,75 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a new ZenMapCombineExpr.
         /// </summary>
-        /// <param name="map1">The map expr.</param>
-        /// <param name="map2">The map expr.</param>
-        /// <param name="combinationType">The combination type.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns>The new Zen expr.</returns>
         private static Zen<Map<TKey, SetUnit>> Simplify(
-            Zen<Map<TKey, SetUnit>> map1,
-            Zen<Map<TKey, SetUnit>> map2,
-            CombineType combinationType)
+            (Zen<Map<TKey, SetUnit>> map1, Zen<Map<TKey, SetUnit>> map2, CombineType combinationType) args)
         {
             // a union a = a
             // a inter a = a
             // a minus a = {}
-            if (map1.Equals(map2))
+            if (args.map1.Equals(args.map2))
             {
-                return combinationType == CombineType.Difference ? Zen.EmptyMap<TKey, SetUnit>() : map1;
+                return args.combinationType == CombineType.Difference ? Zen.EmptyMap<TKey, SetUnit>() : args.map1;
             }
 
             // {} union a == a
             // {} inter a == {}
             // {} minus a == {}
-            if (map1 is ZenConstantExpr<Map<TKey, SetUnit>> ce1 && ce1.Value.Values.Count == 0)
+            if (args.map1 is ZenConstantExpr<Map<TKey, SetUnit>> ce1 && ce1.Value.Values.Count == 0)
             {
-                return combinationType == CombineType.Union ? map2 : map1;
+                return args.combinationType == CombineType.Union ? args.map2 : args.map1;
             }
 
             // a union {} == a
             // a inter {} == {}
             // a minus {} == a
-            if (map2 is ZenConstantExpr<Map<TKey, SetUnit>> ce2 && ce2.Value.Values.Count == 0)
+            if (args.map2 is ZenConstantExpr<Map<TKey, SetUnit>> ce2 && ce2.Value.Values.Count == 0)
             {
-                return combinationType == CombineType.Intersect ? map2 : map1;
+                return args.combinationType == CombineType.Intersect ? args.map2 : args.map1;
             }
 
             // (a union b) union b == (a union b)
             // (a union b) union a == (a union b)
             // (a inter b) inter b == (a inter b)
             // (a inter b) inter a == (a inter b)
-            if (map1 is ZenMapCombineExpr<TKey> e1 &&
-                e1.CombinationType == combinationType &&
-                combinationType != CombineType.Difference &&
-                (e1.MapExpr1.Equals(map2) || e1.MapExpr2.Equals(map2)))
+            if (args.map1 is ZenMapCombineExpr<TKey> e1 &&
+                e1.CombinationType == args.combinationType &&
+                args.combinationType != CombineType.Difference &&
+                (e1.MapExpr1.Equals(args.map2) || e1.MapExpr2.Equals(args.map2)))
             {
-                return map1;
+                return args.map1;
             }
 
             // a union (a union b) == (a union b)
             // b union (a union b) == (a union b)
             // a inter (a inter b) == (a inter b)
             // b inter (a inter b) == (a inter b)
-            if (map2 is ZenMapCombineExpr<TKey> e2 &&
-                e2.CombinationType == combinationType &&
-                combinationType != CombineType.Difference &&
-                (e2.MapExpr1.Equals(map1) || e2.MapExpr2.Equals(map1)))
+            if (args.map2 is ZenMapCombineExpr<TKey> e2 &&
+                e2.CombinationType == args.combinationType &&
+                args.combinationType != CombineType.Difference &&
+                (e2.MapExpr1.Equals(args.map1) || e2.MapExpr2.Equals(args.map1)))
             {
-                return map2;
+                return args.map2;
             }
 
             // (a minus b) minus a == {}
             // (a minus b) minus b == a minus b
-            if (map1 is ZenMapCombineExpr<TKey> e3 && combinationType == CombineType.Difference)
+            if (args.map1 is ZenMapCombineExpr<TKey> e3 && args.combinationType == CombineType.Difference)
             {
-                if (e3.CombinationType == CombineType.Difference && e3.MapExpr1.Equals(map2))
+                if (e3.CombinationType == CombineType.Difference && e3.MapExpr1.Equals(args.map2))
                 {
                     return Zen.EmptyMap<TKey, SetUnit>();
                 }
 
-                if (e3.CombinationType == CombineType.Difference && e3.MapExpr2.Equals(map2))
+                if (e3.CombinationType == CombineType.Difference && e3.MapExpr2.Equals(args.map2))
                 {
-                    return map1;
+                    return args.map1;
                 }
             }
 
-            return new ZenMapCombineExpr<TKey>(map1, map2, combinationType);
+            return new ZenMapCombineExpr<TKey>(args.map1, args.map2, args.combinationType);
         }
 
         /// <summary>
@@ -133,7 +123,7 @@ namespace ZenLib
             Contract.AssertNotNull(mapExpr2);
 
             var k = (mapExpr1.Id, mapExpr2.Id, (int)combineType);
-            hashConsTable.GetOrAdd(k, (mapExpr1, mapExpr2, combineType), createFunc, out var v);
+            hashConsTable.GetOrAdd(k, (mapExpr1, mapExpr2, combineType), Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenMapDeleteExpr.cs
+++ b/ZenLib/Language/Ast/ZenMapDeleteExpr.cs
@@ -12,12 +12,6 @@ namespace ZenLib
     internal sealed class ZenMapDeleteExpr<TKey, TValue> : Zen<Map<TKey, TValue>>
     {
         /// <summary>
-        /// Hash cons table for ZenMapDeleteExpr.
-        /// </summary>
-        private static HashConsTable<(long, long), Zen<Map<TKey, TValue>>> hashConsTable =
-            new HashConsTable<(long, long), Zen<Map<TKey, TValue>>>();
-
-        /// <summary>
         /// Gets the map expr.
         /// </summary>
         public Zen<Map<TKey, TValue>> MapExpr { get; }
@@ -46,7 +40,8 @@ namespace ZenLib
             Contract.AssertNotNull(key);
 
             var k = (mapExpr.Id, key.Id);
-            hashConsTable.GetOrAdd(k, (mapExpr, key), Simplify, out var v);
+            var flyweight = ZenAstCache<ZenMapDeleteExpr<TKey, TValue>, (long, long), Zen<Map<TKey, TValue>>>.Flyweight;
+            flyweight.GetOrAdd(k, (mapExpr, key), Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenMapDeleteExpr.cs
+++ b/ZenLib/Language/Ast/ZenMapDeleteExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -13,16 +12,10 @@ namespace ZenLib
     internal sealed class ZenMapDeleteExpr<TKey, TValue> : Zen<Map<TKey, TValue>>
     {
         /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<Map<TKey, TValue>>, Zen<TKey>), ZenMapDeleteExpr<TKey, TValue>> createFunc = (v) =>
-            new ZenMapDeleteExpr<TKey, TValue>(v.Item1, v.Item2);
-
-        /// <summary>
         /// Hash cons table for ZenMapDeleteExpr.
         /// </summary>
-        private static HashConsTable<(long, long), ZenMapDeleteExpr<TKey, TValue>> hashConsTable =
-            new HashConsTable<(long, long), ZenMapDeleteExpr<TKey, TValue>>();
+        private static HashConsTable<(long, long), Zen<Map<TKey, TValue>>> hashConsTable =
+            new HashConsTable<(long, long), Zen<Map<TKey, TValue>>>();
 
         /// <summary>
         /// Gets the map expr.
@@ -35,18 +28,25 @@ namespace ZenLib
         public Zen<TKey> KeyExpr { get; }
 
         /// <summary>
+        /// Simplify and create a ZenMapDeleteExpr.
+        /// </summary>
+        /// <param name="args">The arguments.</param>
+        /// <returns>A new Zen expr.</returns>
+        private static Zen<Map<TKey, TValue>> Simplify((Zen<Map<TKey, TValue>> e1, Zen<TKey> e2) args) => new ZenMapDeleteExpr<TKey, TValue>(args.e1, args.e2);
+
+        /// <summary>
         /// Create a new ZenMapDeleteExpr.
         /// </summary>
         /// <param name="mapExpr">The map expr.</param>
         /// <param name="key">The key expr.</param>
         /// <returns>The new expr.</returns>
-        public static ZenMapDeleteExpr<TKey, TValue> Create(Zen<Map<TKey, TValue>> mapExpr, Zen<TKey> key)
+        public static Zen<Map<TKey, TValue>> Create(Zen<Map<TKey, TValue>> mapExpr, Zen<TKey> key)
         {
             Contract.AssertNotNull(mapExpr);
             Contract.AssertNotNull(key);
 
             var k = (mapExpr.Id, key.Id);
-            hashConsTable.GetOrAdd(k, (mapExpr, key), createFunc, out var v);
+            hashConsTable.GetOrAdd(k, (mapExpr, key), Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenMapGetExpr.cs
+++ b/ZenLib/Language/Ast/ZenMapGetExpr.cs
@@ -12,12 +12,6 @@ namespace ZenLib
     internal sealed class ZenMapGetExpr<TKey, TValue> : Zen<Option<TValue>>
     {
         /// <summary>
-        /// Hash cons table for ZenMapAddExpr.
-        /// </summary>
-        private static HashConsTable<(long, long), Zen<Option<TValue>>> hashConsTable =
-            new HashConsTable<(long, long), Zen<Option<TValue>>>();
-
-        /// <summary>
         /// Gets the map expr.
         /// </summary>
         public Zen<Map<TKey, TValue>> MapExpr { get; }
@@ -64,7 +58,8 @@ namespace ZenLib
             Contract.AssertNotNull(key);
 
             var k = (mapExpr.Id, key.Id);
-            hashConsTable.GetOrAdd(k, (mapExpr, key), Simplify, out var v);
+            var flyweight = ZenAstCache<ZenMapGetExpr<TKey, TValue>, (long, long), Zen<Option<TValue>>>.Flyweight;
+            flyweight.GetOrAdd(k, (mapExpr, key), Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenMapSetExpr.cs
+++ b/ZenLib/Language/Ast/ZenMapSetExpr.cs
@@ -12,12 +12,6 @@ namespace ZenLib
     internal sealed class ZenMapSetExpr<TKey, TValue> : Zen<Map<TKey, TValue>>
     {
         /// <summary>
-        /// Hash cons table for ZenMapSetExpr.
-        /// </summary>
-        private static HashConsTable<(long, long, long), Zen<Map<TKey, TValue>>> hashConsTable =
-            new HashConsTable<(long, long, long), Zen<Map<TKey, TValue>>>();
-
-        /// <summary>
         /// Gets the map expr.
         /// </summary>
         public Zen<Map<TKey, TValue>> MapExpr { get; }
@@ -66,7 +60,8 @@ namespace ZenLib
             Contract.AssertNotNull(value);
 
             var k = (mapExpr.Id, key.Id, value.Id);
-            hashConsTable.GetOrAdd(k, (mapExpr, key, value), Simplify, out var v);
+            var flyweight = ZenAstCache<ZenMapSetExpr<TKey, TValue>, (long, long, long), Zen<Map<TKey, TValue>>>.Flyweight;
+            flyweight.GetOrAdd(k, (mapExpr, key, value), Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenNotExpr.cs
+++ b/ZenLib/Language/Ast/ZenNotExpr.cs
@@ -12,11 +12,6 @@ namespace ZenLib
     internal sealed class ZenNotExpr : Zen<bool>
     {
         /// <summary>
-        /// Hash cons table for ZenNotExpr.
-        /// </summary>
-        private static HashConsTable<long, Zen<bool>> hashConsTable = new HashConsTable<long, Zen<bool>>();
-
-        /// <summary>
         /// Gets the expression.
         /// </summary>
         internal Zen<bool> Expr { get; }
@@ -50,7 +45,8 @@ namespace ZenLib
         {
             Contract.AssertNotNull(expr);
 
-            hashConsTable.GetOrAdd(expr.Id, expr, Simplify, out var value);
+            var flyweight = ZenAstCache<ZenNotExpr, long, Zen<bool>>.Flyweight;
+            flyweight.GetOrAdd(expr.Id, expr, Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqAtExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqAtExpr.cs
@@ -13,11 +13,6 @@ namespace ZenLib
     internal sealed class ZenSeqAtExpr<T> : Zen<Seq<T>>
     {
         /// <summary>
-        /// Hash cons table for ZenSeqAtExpr.
-        /// </summary>
-        private static HashConsTable<(long, long), Zen<Seq<T>>> hashConsTable = new HashConsTable<(long, long), Zen<Seq<T>>>();
-
-        /// <summary>
         /// Gets the seq expression.
         /// </summary>
         internal Zen<Seq<T>> SeqExpr { get; }
@@ -46,7 +41,8 @@ namespace ZenLib
             Contract.AssertNotNull(expr2);
 
             var key = (expr1.Id, expr2.Id);
-            hashConsTable.GetOrAdd(key, (expr1, expr2), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenSeqAtExpr<T>, (long, long), Zen<Seq<T>>>.Flyweight;
+            flyweight.GetOrAdd(key, (expr1, expr2), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqAtExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqAtExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Numerics;
 
@@ -13,11 +12,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenSeqAtExpr<T> : Zen<Seq<T>>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<Seq<T>>, Zen<BigInteger>), Zen<Seq<T>>> createFunc = (v) => Simplify(v.Item1, v.Item2);
-
         /// <summary>
         /// Hash cons table for ZenSeqAtExpr.
         /// </summary>
@@ -36,13 +30,9 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a ZenSeqAtExpr.
         /// </summary>
-        /// <param name="e1">The seq expr.</param>
-        /// <param name="e2">The index expr.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns>The new Zen expr.</returns>
-        public static Zen<Seq<T>> Simplify(Zen<Seq<T>> e1, Zen<BigInteger> e2)
-        {
-            return new ZenSeqAtExpr<T>(e1, e2);
-        }
+        public static Zen<Seq<T>> Simplify((Zen<Seq<T>> e1, Zen<BigInteger> e2) args) => new ZenSeqAtExpr<T>(args.e1, args.e2);
 
         /// <summary>
         /// Create a new ZenSeqAtExpr.
@@ -56,7 +46,7 @@ namespace ZenLib
             Contract.AssertNotNull(expr2);
 
             var key = (expr1.Id, expr2.Id);
-            hashConsTable.GetOrAdd(key, (expr1, expr2), createFunc, out var value);
+            hashConsTable.GetOrAdd(key, (expr1, expr2), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqConcatExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqConcatExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -12,12 +11,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenSeqConcatExpr<T> : Zen<Seq<T>>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<Seq<T>>, Zen<Seq<T>>), Zen<Seq<T>>> createFunc = (v) =>
-            Simplify(v.Item1, v.Item2);
-
         /// <summary>
         /// Hash cons table for ZenSeqConcatExpr.
         /// </summary>
@@ -37,22 +30,21 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a new ZenSeqConcatExpr.
         /// </summary>
-        /// <param name="seqExpr1">The seq expr.</param>
-        /// <param name="seqExpr2">The seq expr.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns>The new Zen expr.</returns>
-        private static Zen<Seq<T>> Simplify(Zen<Seq<T>> seqExpr1, Zen<Seq<T>> seqExpr2)
+        private static Zen<Seq<T>> Simplify((Zen<Seq<T>> seqExpr1, Zen<Seq<T>> seqExpr2) args)
         {
-            if (seqExpr1 is ZenConstantExpr<Seq<T>> e1 && e1.Value.Length() == 0)
+            if (args.seqExpr1 is ZenConstantExpr<Seq<T>> e1 && e1.Value.Length() == 0)
             {
-                return seqExpr2;
+                return args.seqExpr2;
             }
 
-            if (seqExpr2 is ZenConstantExpr<Seq<T>> e2 && e2.Value.Length() == 0)
+            if (args.seqExpr2 is ZenConstantExpr<Seq<T>> e2 && e2.Value.Length() == 0)
             {
-                return seqExpr1;
+                return args.seqExpr1;
             }
 
-            return new ZenSeqConcatExpr<T>(seqExpr1, seqExpr2);
+            return new ZenSeqConcatExpr<T>(args.seqExpr1, args.seqExpr2);
         }
 
         /// <summary>
@@ -67,7 +59,7 @@ namespace ZenLib
             Contract.AssertNotNull(seqExpr2);
 
             var k = (seqExpr1.Id, seqExpr2.Id);
-            hashConsTable.GetOrAdd(k, (seqExpr1, seqExpr2), createFunc, out var v);
+            hashConsTable.GetOrAdd(k, (seqExpr1, seqExpr2), Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqConcatExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqConcatExpr.cs
@@ -12,12 +12,6 @@ namespace ZenLib
     internal sealed class ZenSeqConcatExpr<T> : Zen<Seq<T>>
     {
         /// <summary>
-        /// Hash cons table for ZenSeqConcatExpr.
-        /// </summary>
-        private static HashConsTable<(long, long), Zen<Seq<T>>> hashConsTable =
-            new HashConsTable<(long, long), Zen<Seq<T>>>();
-
-        /// <summary>
         /// Gets the first seq expr.
         /// </summary>
         public Zen<Seq<T>> SeqExpr1 { get; }
@@ -59,7 +53,8 @@ namespace ZenLib
             Contract.AssertNotNull(seqExpr2);
 
             var k = (seqExpr1.Id, seqExpr2.Id);
-            hashConsTable.GetOrAdd(k, (seqExpr1, seqExpr2), Simplify, out var v);
+            var flyweight = ZenAstCache<ZenSeqConcatExpr<T>, (long, long), Zen<Seq<T>>>.Flyweight;
+            flyweight.GetOrAdd(k, (seqExpr1, seqExpr2), Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqContainsExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqContainsExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -12,11 +11,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenSeqContainsExpr<T> : Zen<bool>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<Seq<T>>, Zen<Seq<T>>, SeqContainmentType), Zen<bool>> createFunc = (v) => Simplify(v.Item1, v.Item2, v.Item3);
-
         /// <summary>
         /// Hash cons table for ZenSeqContainsExpr.
         /// </summary>
@@ -40,13 +34,11 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a ZenSeqContainsExpr.
         /// </summary>
-        /// <param name="e1">The seq expr.</param>
-        /// <param name="e2">The subseq expr.</param>
-        /// <param name="containmentType">The containment type.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns>The new Zen expr.</returns>
-        public static Zen<bool> Simplify(Zen<Seq<T>> e1, Zen<Seq<T>> e2, SeqContainmentType containmentType)
+        public static Zen<bool> Simplify((Zen<Seq<T>> e1, Zen<Seq<T>> e2, SeqContainmentType containmentType) args)
         {
-            return new ZenSeqContainsExpr<T>(e1, e2, containmentType);
+            return new ZenSeqContainsExpr<T>(args.e1, args.e2, args.containmentType);
         }
 
         /// <summary>
@@ -62,7 +54,7 @@ namespace ZenLib
             Contract.AssertNotNull(expr2);
 
             var key = (expr1.Id, expr2.Id, (int)containmentType);
-            hashConsTable.GetOrAdd(key, (expr1, expr2, containmentType), createFunc, out var value);
+            hashConsTable.GetOrAdd(key, (expr1, expr2, containmentType), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqContainsExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqContainsExpr.cs
@@ -12,11 +12,6 @@ namespace ZenLib
     internal sealed class ZenSeqContainsExpr<T> : Zen<bool>
     {
         /// <summary>
-        /// Hash cons table for ZenSeqContainsExpr.
-        /// </summary>
-        private static HashConsTable<(long, long, int), Zen<bool>> hashConsTable = new HashConsTable<(long, long, int), Zen<bool>>();
-
-        /// <summary>
         /// Gets the seq expression.
         /// </summary>
         internal Zen<Seq<T>> SeqExpr { get; }
@@ -54,7 +49,8 @@ namespace ZenLib
             Contract.AssertNotNull(expr2);
 
             var key = (expr1.Id, expr2.Id, (int)containmentType);
-            hashConsTable.GetOrAdd(key, (expr1, expr2, containmentType), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenSeqContainsExpr<T>, (long, long, int), Zen<bool>>.Flyweight;
+            flyweight.GetOrAdd(key, (expr1, expr2, containmentType), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqIndexOfExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqIndexOfExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Numerics;
 
@@ -13,11 +12,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenSeqIndexOfExpr<T> : Zen<BigInteger>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<Seq<T>>, Zen<Seq<T>>, Zen<BigInteger>), Zen<BigInteger>> createFunc = (v) => Simplify(v.Item1, v.Item2, v.Item3);
-
         /// <summary>
         /// Hash cons table for ZenStringIndexOfExpr.
         /// </summary>
@@ -41,13 +35,11 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a ZenSeqIndexOfExpr.
         /// </summary>
-        /// <param name="e1">The seq expr.</param>
-        /// <param name="e2">The subseq expr.</param>
-        /// <param name="e3">The offset expr.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns></returns>
-        public static Zen<BigInteger> Simplify(Zen<Seq<T>> e1, Zen<Seq<T>> e2, Zen<BigInteger> e3)
+        public static Zen<BigInteger> Simplify((Zen<Seq<T>> e1, Zen<Seq<T>> e2, Zen<BigInteger> e3) args)
         {
-            return new ZenSeqIndexOfExpr<T>(e1, e2, e3);
+            return new ZenSeqIndexOfExpr<T>(args.e1, args.e2, args.e3);
         }
 
         /// <summary>
@@ -64,7 +56,7 @@ namespace ZenLib
             Contract.AssertNotNull(expr3);
 
             var key = (expr1.Id, expr2.Id, expr3.Id);
-            hashConsTable.GetOrAdd(key, (expr1, expr2, expr3), createFunc, out var value);
+            hashConsTable.GetOrAdd(key, (expr1, expr2, expr3), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqIndexOfExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqIndexOfExpr.cs
@@ -13,11 +13,6 @@ namespace ZenLib
     internal sealed class ZenSeqIndexOfExpr<T> : Zen<BigInteger>
     {
         /// <summary>
-        /// Hash cons table for ZenStringIndexOfExpr.
-        /// </summary>
-        private static HashConsTable<(long, long, long), Zen<BigInteger>> hashConsTable = new HashConsTable<(long, long, long), Zen<BigInteger>>();
-
-        /// <summary>
         /// Gets the seq expression.
         /// </summary>
         internal Zen<Seq<T>> SeqExpr { get; }
@@ -56,7 +51,8 @@ namespace ZenLib
             Contract.AssertNotNull(expr3);
 
             var key = (expr1.Id, expr2.Id, expr3.Id);
-            hashConsTable.GetOrAdd(key, (expr1, expr2, expr3), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenSeqIndexOfExpr<T>, (long, long, long), Zen<BigInteger>>.Flyweight;
+            flyweight.GetOrAdd(key, (expr1, expr2, expr3), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqLengthExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqLengthExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Numerics;
 
@@ -13,11 +12,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenSeqLengthExpr<T> : Zen<BigInteger>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<Zen<Seq<T>>, Zen<BigInteger>> createFunc = (v) => Simplify(v);
-
         /// <summary>
         /// Hash cons table for ZenSeqLengthExpr.
         /// </summary>
@@ -34,10 +28,7 @@ namespace ZenLib
         /// </summary>
         /// <param name="seqExpr">The seq expr.</param>
         /// <returns>The new Zen expr.</returns>
-        private static Zen<BigInteger> Simplify(Zen<Seq<T>> seqExpr)
-        {
-            return new ZenSeqLengthExpr<T>(seqExpr);
-        }
+        private static Zen<BigInteger> Simplify(Zen<Seq<T>> seqExpr) => new ZenSeqLengthExpr<T>(seqExpr);
 
         /// <summary>
         /// Create a new ZenSeqLengthExpr.
@@ -48,7 +39,7 @@ namespace ZenLib
         {
             Contract.AssertNotNull(seqExpr);
 
-            hashConsTable.GetOrAdd(seqExpr.Id, seqExpr, createFunc, out var v);
+            hashConsTable.GetOrAdd(seqExpr.Id, seqExpr, Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqLengthExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqLengthExpr.cs
@@ -13,12 +13,6 @@ namespace ZenLib
     internal sealed class ZenSeqLengthExpr<T> : Zen<BigInteger>
     {
         /// <summary>
-        /// Hash cons table for ZenSeqLengthExpr.
-        /// </summary>
-        private static HashConsTable<long, Zen<BigInteger>> hashConsTable =
-            new HashConsTable<long, Zen<BigInteger>>();
-
-        /// <summary>
         /// Gets the seq expr.
         /// </summary>
         public Zen<Seq<T>> SeqExpr { get; }
@@ -39,7 +33,8 @@ namespace ZenLib
         {
             Contract.AssertNotNull(seqExpr);
 
-            hashConsTable.GetOrAdd(seqExpr.Id, seqExpr, Simplify, out var v);
+            var flyweight = ZenAstCache<ZenSeqLengthExpr<T>, long, Zen<BigInteger>>.Flyweight;
+            flyweight.GetOrAdd(seqExpr.Id, seqExpr, Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqNthExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqNthExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Numerics;
 
@@ -13,11 +12,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenSeqNthExpr<T> : Zen<T>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<Seq<T>>, Zen<BigInteger>), Zen<T>> createFunc = (v) => Simplify(v.Item1, v.Item2);
-
         /// <summary>
         /// Hash cons table for ZenSeqAtExpr.
         /// </summary>
@@ -36,13 +30,9 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a ZenSeqNthExpr.
         /// </summary>
-        /// <param name="e1">The seq expr.</param>
-        /// <param name="e2">The index expr.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns>The new Zen expr.</returns>
-        public static Zen<T> Simplify(Zen<Seq<T>> e1, Zen<BigInteger> e2)
-        {
-            return new ZenSeqNthExpr<T>(e1, e2);
-        }
+        public static Zen<T> Simplify((Zen<Seq<T>> e1, Zen<BigInteger> e2) args) => new ZenSeqNthExpr<T>(args.e1, args.e2);
 
         /// <summary>
         /// Create a new ZenSeqAtExpr.
@@ -56,7 +46,7 @@ namespace ZenLib
             Contract.AssertNotNull(expr2);
 
             var key = (expr1.Id, expr2.Id);
-            hashConsTable.GetOrAdd(key, (expr1, expr2), createFunc, out var value);
+            hashConsTable.GetOrAdd(key, (expr1, expr2), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqNthExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqNthExpr.cs
@@ -13,11 +13,6 @@ namespace ZenLib
     internal sealed class ZenSeqNthExpr<T> : Zen<T>
     {
         /// <summary>
-        /// Hash cons table for ZenSeqAtExpr.
-        /// </summary>
-        private static HashConsTable<(long, long), Zen<T>> hashConsTable = new HashConsTable<(long, long), Zen<T>>();
-
-        /// <summary>
         /// Gets the seq expression.
         /// </summary>
         internal Zen<Seq<T>> SeqExpr { get; }
@@ -46,7 +41,8 @@ namespace ZenLib
             Contract.AssertNotNull(expr2);
 
             var key = (expr1.Id, expr2.Id);
-            hashConsTable.GetOrAdd(key, (expr1, expr2), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenSeqNthExpr<T>, (long, long), Zen<T>>.Flyweight;
+            flyweight.GetOrAdd(key, (expr1, expr2), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqRegexExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqRegexExpr.cs
@@ -12,11 +12,6 @@ namespace ZenLib
     internal sealed class ZenSeqRegexExpr<T> : Zen<bool>
     {
         /// <summary>
-        /// Hash cons table for ZenSeqContainsExpr.
-        /// </summary>
-        private static HashConsTable<(long, long), Zen<bool>> hashConsTable = new HashConsTable<(long, long), Zen<bool>>();
-
-        /// <summary>
         /// Gets the seq expression.
         /// </summary>
         internal Zen<Seq<T>> SeqExpr { get; }
@@ -45,7 +40,8 @@ namespace ZenLib
             Contract.AssertNotNull(expr2);
 
             var key = (expr1.Id, expr2.Id);
-            hashConsTable.GetOrAdd(key, (expr1, expr2), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenSeqRegexExpr<T>, (long, long), Zen<bool>>.Flyweight;
+            flyweight.GetOrAdd(key, (expr1, expr2), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqRegexExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqRegexExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -12,11 +11,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenSeqRegexExpr<T> : Zen<bool>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<Seq<T>>, Regex<T>), Zen<bool>> createFunc = (v) => Simplify(v.Item1, v.Item2);
-
         /// <summary>
         /// Hash cons table for ZenSeqContainsExpr.
         /// </summary>
@@ -35,13 +29,9 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a ZenSeqRegexExpr.
         /// </summary>
-        /// <param name="e1">The seq expr.</param>
-        /// <param name="e2">The Regex expr.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns>The new Zen expr.</returns>
-        public static Zen<bool> Simplify(Zen<Seq<T>> e1, Regex<T> e2)
-        {
-            return new ZenSeqRegexExpr<T>(e1, e2);
-        }
+        public static Zen<bool> Simplify((Zen<Seq<T>> e1, Regex<T> e2) args) => new ZenSeqRegexExpr<T>(args.e1, args.e2);
 
         /// <summary>
         /// Create a new ZenSeqRegexExpr.
@@ -55,7 +45,7 @@ namespace ZenLib
             Contract.AssertNotNull(expr2);
 
             var key = (expr1.Id, expr2.Id);
-            hashConsTable.GetOrAdd(key, (expr1, expr2), createFunc, out var value);
+            hashConsTable.GetOrAdd(key, (expr1, expr2), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqReplaceFirstExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqReplaceFirstExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -12,11 +11,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenSeqReplaceFirstExpr<T> : Zen<Seq<T>>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<Seq<T>>, Zen<Seq<T>>, Zen<Seq<T>>), Zen<Seq<T>>> createFunc = (v) => Simplify(v.Item1, v.Item2, v.Item3);
-
         /// <summary>
         /// Hash cons table for ZenSeqReplaceFirstExpr.
         /// </summary>
@@ -40,13 +34,11 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a new ZenSeqReplaceFirstExpr.
         /// </summary>
-        /// <param name="e1">The seq expr.</param>
-        /// <param name="e2">The subseq expr.</param>
-        /// <param name="e3">The replacement expr.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns>The new Zen expr.</returns>
-        public static Zen<Seq<T>> Simplify(Zen<Seq<T>> e1, Zen<Seq<T>> e2, Zen<Seq<T>> e3)
+        public static Zen<Seq<T>> Simplify((Zen<Seq<T>> e1, Zen<Seq<T>> e2, Zen<Seq<T>> e3) args)
         {
-            return new ZenSeqReplaceFirstExpr<T>(e1, e2, e3);
+            return new ZenSeqReplaceFirstExpr<T>(args.e1, args.e2, args.e3);
         }
 
         /// <summary>
@@ -63,7 +55,7 @@ namespace ZenLib
             Contract.AssertNotNull(expr3);
 
             var key = (expr1.Id, expr2.Id, expr3.Id);
-            hashConsTable.GetOrAdd(key, (expr1, expr2, expr3), createFunc, out var value);
+            hashConsTable.GetOrAdd(key, (expr1, expr2, expr3), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqReplaceFirstExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqReplaceFirstExpr.cs
@@ -12,11 +12,6 @@ namespace ZenLib
     internal sealed class ZenSeqReplaceFirstExpr<T> : Zen<Seq<T>>
     {
         /// <summary>
-        /// Hash cons table for ZenSeqReplaceFirstExpr.
-        /// </summary>
-        private static HashConsTable<(long, long, long), Zen<Seq<T>>> hashConsTable = new HashConsTable<(long, long, long), Zen<Seq<T>>>();
-
-        /// <summary>
         /// Gets the seq expression.
         /// </summary>
         internal Zen<Seq<T>> SeqExpr { get; }
@@ -55,7 +50,8 @@ namespace ZenLib
             Contract.AssertNotNull(expr3);
 
             var key = (expr1.Id, expr2.Id, expr3.Id);
-            hashConsTable.GetOrAdd(key, (expr1, expr2, expr3), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenSeqReplaceFirstExpr<T>, (long, long, long), Zen<Seq<T>>>.Flyweight;
+            flyweight.GetOrAdd(key, (expr1, expr2, expr3), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqSliceExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqSliceExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Numerics;
 
@@ -13,11 +12,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenSeqSliceExpr<T> : Zen<Seq<T>>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<(Zen<Seq<T>>, Zen<BigInteger>, Zen<BigInteger>), Zen<Seq<T>>> createFunc = (v) => Simplify(v.Item1, v.Item2, v.Item3);
-
         /// <summary>
         /// Hash cons table for ZenSeqSliceExpr.
         /// </summary>
@@ -41,13 +35,11 @@ namespace ZenLib
         /// <summary>
         /// Simplify and create a new ZenSeqSliceExpr.
         /// </summary>
-        /// <param name="e1">The seq expression.</param>
-        /// <param name="e2">The offset expression.</param>
-        /// <param name="e3">The length expression.</param>
+        /// <param name="args">The arguments.</param>
         /// <returns>The new Zen expr.</returns>
-        public static Zen<Seq<T>> Simplify(Zen<Seq<T>> e1, Zen<BigInteger> e2, Zen<BigInteger> e3)
+        public static Zen<Seq<T>> Simplify((Zen<Seq<T>> e1, Zen<BigInteger> e2, Zen<BigInteger> e3) args)
         {
-            return new ZenSeqSliceExpr<T>(e1, e2, e3);
+            return new ZenSeqSliceExpr<T>(args.e1, args.e2, args.e3);
         }
 
         /// <summary>
@@ -64,7 +56,7 @@ namespace ZenLib
             Contract.AssertNotNull(expr3);
 
             var key = (expr1.Id, expr2.Id, expr3.Id);
-            hashConsTable.GetOrAdd(key, (expr1, expr2, expr3), createFunc, out var value);
+            hashConsTable.GetOrAdd(key, (expr1, expr2, expr3), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqSliceExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqSliceExpr.cs
@@ -13,11 +13,6 @@ namespace ZenLib
     internal sealed class ZenSeqSliceExpr<T> : Zen<Seq<T>>
     {
         /// <summary>
-        /// Hash cons table for ZenSeqSliceExpr.
-        /// </summary>
-        private static HashConsTable<(long, long, long), Zen<Seq<T>>> hashConsTable = new HashConsTable<(long, long, long), Zen<Seq<T>>>();
-
-        /// <summary>
         /// Gets the seq expression.
         /// </summary>
         internal Zen<Seq<T>> SeqExpr { get; }
@@ -56,7 +51,8 @@ namespace ZenLib
             Contract.AssertNotNull(expr3);
 
             var key = (expr1.Id, expr2.Id, expr3.Id);
-            hashConsTable.GetOrAdd(key, (expr1, expr2, expr3), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenSeqSliceExpr<T>, (long, long, long), Zen<Seq<T>>>.Flyweight;
+            flyweight.GetOrAdd(key, (expr1, expr2, expr3), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqUnitExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqUnitExpr.cs
@@ -4,7 +4,6 @@
 
 namespace ZenLib
 {
-    using System;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -12,11 +11,6 @@ namespace ZenLib
     /// </summary>
     internal sealed class ZenSeqUnitExpr<T> : Zen<Seq<T>>
     {
-        /// <summary>
-        /// Static creation function for hash consing.
-        /// </summary>
-        private static Func<Zen<T>, Zen<Seq<T>>> createFunc = (v) => new ZenSeqUnitExpr<T>(v);
-
         /// <summary>
         /// Hash cons table for ZenSeqUnitExpr.
         /// </summary>
@@ -28,6 +22,13 @@ namespace ZenLib
         public Zen<T> ValueExpr { get; }
 
         /// <summary>
+        /// Simplify and create a ZenSeqUnitExpr.
+        /// </summary>
+        /// <param name="e">The expression.</param>
+        /// <returns>A new Zen expr.</returns>
+        private static Zen<Seq<T>> Simplify(Zen<T> e) => new ZenSeqUnitExpr<T>(e);
+
+        /// <summary>
         /// Create a new ZenSeqUnitExpr.
         /// </summary>
         /// <param name="valueExpr">The value expr.</param>
@@ -36,7 +37,7 @@ namespace ZenLib
         {
             Contract.AssertNotNull(valueExpr);
 
-            hashConsTable.GetOrAdd(valueExpr.Id, valueExpr, createFunc, out var v);
+            hashConsTable.GetOrAdd(valueExpr.Id, valueExpr, Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenSeqUnitExpr.cs
+++ b/ZenLib/Language/Ast/ZenSeqUnitExpr.cs
@@ -12,11 +12,6 @@ namespace ZenLib
     internal sealed class ZenSeqUnitExpr<T> : Zen<Seq<T>>
     {
         /// <summary>
-        /// Hash cons table for ZenSeqUnitExpr.
-        /// </summary>
-        private static HashConsTable<long, Zen<Seq<T>>> hashConsTable = new HashConsTable<long, Zen<Seq<T>>>();
-
-        /// <summary>
         /// Gets the value expr.
         /// </summary>
         public Zen<T> ValueExpr { get; }
@@ -37,7 +32,8 @@ namespace ZenLib
         {
             Contract.AssertNotNull(valueExpr);
 
-            hashConsTable.GetOrAdd(valueExpr.Id, valueExpr, Simplify, out var v);
+            var flyweight = ZenAstCache<ZenSeqUnitExpr<T>, long, Zen<Seq<T>>>.Flyweight;
+            flyweight.GetOrAdd(valueExpr.Id, valueExpr, Simplify, out var v);
             return v;
         }
 

--- a/ZenLib/Language/Ast/ZenWithFieldExpr.cs
+++ b/ZenLib/Language/Ast/ZenWithFieldExpr.cs
@@ -12,11 +12,6 @@ namespace ZenLib
     internal sealed class ZenWithFieldExpr<T1, T2> : Zen<T1>
     {
         /// <summary>
-        /// Hash cons table for ZenWithFieldExpr.
-        /// </summary>
-        private static HashConsTable<(long, string, long), Zen<T1>> hashConsTable = new HashConsTable<(long, string, long), Zen<T1>>();
-
-        /// <summary>
         /// Gets the expression.
         /// </summary>
         public Zen<T1> Expr { get; }
@@ -69,7 +64,8 @@ namespace ZenLib
             Contract.AssertFieldOrProperty(typeof(T1), typeof(T2), fieldName);
 
             var key = (expr.Id, fieldName, fieldValue.Id);
-            hashConsTable.GetOrAdd(key, (expr, fieldName, fieldValue), Simplify, out var value);
+            var flyweight = ZenAstCache<ZenWithFieldExpr<T1, T2>, (long, string, long), Zen<T1>>.Flyweight;
+            flyweight.GetOrAdd(key, (expr, fieldName, fieldValue), Simplify, out var value);
             return value;
         }
 

--- a/ZenLib/Language/ZenConstraint.cs
+++ b/ZenLib/Language/ZenConstraint.cs
@@ -33,7 +33,7 @@ namespace ZenLib
             int listSize = 5,
             Solver.SolverType backend = Solver.SolverType.Z3)
         {
-            return this.Find((i, o) => o, input, listSize, backend);
+            return Find((i, o) => o, input, listSize, backend);
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace ZenLib
             int depth = 5,
             Solver.SolverType backend = Solver.SolverType.Z3)
         {
-            return this.FindAll((i, o) => o, input, depth, backend);
+            return FindAll((i, o) => o, input, depth, backend);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace ZenLib
         /// <returns>The set of values.</returns>
         public StateSet<T> StateSet()
         {
-            return this.Transformer().InputSet((i, o) => o);
+            return Transformer().InputSet((i, o) => o);
         }
     }
 
@@ -88,7 +88,7 @@ namespace ZenLib
             int listSize = 5,
             Solver.SolverType backend = Solver.SolverType.Z3)
         {
-            return this.Find((i1, i2, o) => o, input1, input2, listSize, backend);
+            return Find((i1, i2, o) => o, input1, input2, listSize, backend);
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace ZenLib
             int depth = 5,
             Solver.SolverType backend = Solver.SolverType.Z3)
         {
-            return this.FindAll((i1, i2, o) => o, input1, input2, depth, backend);
+            return FindAll((i1, i2, o) => o, input1, input2, depth, backend);
         }
 
         /// <summary>
@@ -114,7 +114,7 @@ namespace ZenLib
         /// <returns>The set of values.</returns>
         public StateSet<Pair<T1, T2>> StateSet()
         {
-            return this.Transformer().InputSet((i, o) => o);
+            return Transformer().InputSet((i, o) => o);
         }
     }
 
@@ -147,7 +147,7 @@ namespace ZenLib
             int listSize = 5,
             Solver.SolverType backend = Solver.SolverType.Z3)
         {
-            return this.Find((i1, i2, i3, o) => o, input1, input2, input3, listSize, backend);
+            return Find((i1, i2, i3, o) => o, input1, input2, input3, listSize, backend);
         }
 
         /// <summary>
@@ -166,7 +166,7 @@ namespace ZenLib
             int depth = 5,
             Solver.SolverType backend = Solver.SolverType.Z3)
         {
-            return this.FindAll((i1, i2, i3, o) => o, input1, input2, input3, depth, backend);
+            return FindAll((i1, i2, i3, o) => o, input1, input2, input3, depth, backend);
         }
 
         /// <summary>
@@ -175,7 +175,7 @@ namespace ZenLib
         /// <returns>The set of values.</returns>
         public StateSet<Pair<T1, T2, T3>> StateSet()
         {
-            return this.Transformer().InputSet((i, o) => o);
+            return Transformer().InputSet((i, o) => o);
         }
     }
 
@@ -210,7 +210,7 @@ namespace ZenLib
             int depth = 5,
             Solver.SolverType backend = Solver.SolverType.Z3)
         {
-            return this.Find((i1, i2, i3, i4, o) => o, input1, input2, input3, input4, depth, backend);
+            return Find((i1, i2, i3, i4, o) => o, input1, input2, input3, input4, depth, backend);
         }
 
         /// <summary>
@@ -231,7 +231,7 @@ namespace ZenLib
             int listSize = 5,
             Solver.SolverType backend = Solver.SolverType.Z3)
         {
-            return this.FindAll((i1, i2, i3, i4, o) => o, input1, input2, input3, input4, listSize, backend);
+            return FindAll((i1, i2, i3, i4, o) => o, input1, input2, input3, input4, listSize, backend);
         }
 
         /// <summary>
@@ -240,7 +240,7 @@ namespace ZenLib
         /// <returns>The set of values.</returns>
         public StateSet<Pair<T1, T2, T3, T4>> StateSet()
         {
-            return this.Transformer().InputSet((i, o) => o);
+            return Transformer().InputSet((i, o) => o);
         }
     }
 }

--- a/ZenLib/Language/ZenDefaultValueVisitor.cs
+++ b/ZenLib/Language/ZenDefaultValueVisitor.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // </copyright>
 
-namespace ZenLib.ZenLanguage
+namespace ZenLib
 {
     using System;
     using System.Collections.Generic;

--- a/ZenLib/Language/ZenLiftingVisitor.cs
+++ b/ZenLib/Language/ZenLiftingVisitor.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 // </copyright>
 
-namespace ZenLib.ZenLanguage
+namespace ZenLib
 {
     using System;
     using System.Collections.Generic;

--- a/ZenLib/Regex/Ast/RegexBinopExpr.cs
+++ b/ZenLib/Regex/Ast/RegexBinopExpr.cs
@@ -20,7 +20,7 @@ namespace ZenLib
         /// <summary>
         /// Hash cons table for Regex terms.
         /// </summary>
-        private static HashConsTable<(long, long, int), Regex<T>> hashConsTable = new HashConsTable<(long, long, int), Regex<T>>();
+        private static Flyweight<(long, long, int), Regex<T>> hashConsTable = new Flyweight<(long, long, int), Regex<T>>();
 
         /// <summary>
         /// Gets the first Regex expression.

--- a/ZenLib/Regex/Ast/RegexRangeExpr.cs
+++ b/ZenLib/Regex/Ast/RegexRangeExpr.cs
@@ -20,7 +20,7 @@ namespace ZenLib
         /// <summary>
         /// Hash cons table for Regex terms.
         /// </summary>
-        private static HashConsTable<(T, T), Regex<T>> hashConsTable = new HashConsTable<(T, T), Regex<T>>();
+        private static Flyweight<(T, T), Regex<T>> hashConsTable = new Flyweight<(T, T), Regex<T>>();
 
         /// <summary>
         /// Gets the first Regex expression.

--- a/ZenLib/Regex/Ast/RegexUnopExpr.cs
+++ b/ZenLib/Regex/Ast/RegexUnopExpr.cs
@@ -20,7 +20,7 @@ namespace ZenLib
         /// <summary>
         /// Hash cons table for Regex terms.
         /// </summary>
-        private static HashConsTable<(long, int), Regex<T>> hashConsTable = new HashConsTable<(long, int), Regex<T>>();
+        private static Flyweight<(long, int), Regex<T>> hashConsTable = new Flyweight<(long, int), Regex<T>>();
 
         /// <summary>
         /// Gets the first Regex expression.


### PR DESCRIPTION
Hashconsing tables are spread throughout every AST node type currently. This places the implementations in a single utility class while still maintaining separate tables for better concurrent access.