### PR TITLE
Add optional timeouts

### DIFF
--- a/ZenLib.Bench/AclBench.cs
+++ b/ZenLib.Bench/AclBench.cs
@@ -72,7 +72,8 @@ namespace ZenLibBench
         public void VerifyAclProvenance()
         {
             var f = new ZenFunction<IpHeader, Pair<bool, ushort>>(h => this.Acl.ProcessProvenance(h));
-            var packet = f.Find((p, o) => o.Item2() == (ushort)(this.Acl.Lines.Length + 1), backend: this.Backend);
+            var config = new SolverConfig { SolverType = this.Backend };
+            var packet = f.Find((p, o) => o.Item2() == (ushort)(this.Acl.Lines.Length + 1), config: config);
             f.Evaluate(packet.Value);
         }
     }

--- a/ZenLib.Bench/Program.cs
+++ b/ZenLib.Bench/Program.cs
@@ -5,7 +5,10 @@
 namespace ZenLibBench
 {
     using System;
+    using System.Collections.Generic;
+    using System.Numerics;
     using ZenLib;
+    using ZenLib.Solver;
  
     /// <summary>
     /// Run a collection of benchmarks for Zen.
@@ -18,8 +21,6 @@ namespace ZenLibBench
         /// <param name="args">Command line args.</param>
         static void Main(string[] args)
         {
-            ZenSettings.UseLargeStack = true;
-
             // ZenBench.BenchmarkSets();
             // ZenBench.BenchmarkComparisons();
             // ZenBench.BenchmarkTransformers();

--- a/ZenLib.Bench/RouteBench.cs
+++ b/ZenLib.Bench/RouteBench.cs
@@ -88,10 +88,11 @@ namespace ZenLibBench
         public void VerifyRouteMapProvenance()
         {
             var f = new ZenFunction<Route, Pair<Option<Route>, int>>(this.routeMap.ProcessProvenance);
+            var config = new SolverConfig { SolverType = this.Backend };
             var packet = f.Find(
                 (p, o) => o.Item2() == (this.routeMap.Lines.Count + 1),
                 depth: this.ListSize,
-                backend: this.Backend);
+                config: config);
         }
 
         /// <summary>
@@ -101,10 +102,11 @@ namespace ZenLibBench
         public void VerifyRouteMap()
         {
             var f = new ZenFunction<Route, Option<Route>>(this.routeMap.Process);
+            var config = new SolverConfig { SolverType = this.Backend };
             var packet = f.Find(
                 (p, o) => Not(o.IsSome()),
                 depth: this.ListSize,
-                backend: this.Backend);
+                config: config);
         }
     }
 }

--- a/ZenLib.Tests/CastingTests.cs
+++ b/ZenLib.Tests/CastingTests.cs
@@ -288,7 +288,7 @@ namespace ZenLib.Tests
 
             foreach (var backend in new SolverType[] { SolverType.Z3, SolverType.DecisionDiagrams })
             {
-                var example = zf.Find((s, b) => Zen.And(s == 257, b == 1), backend: backend);
+                var example = zf.Find((s, b) => Zen.And(s == 257, b == 1), config: new SolverConfig { SolverType = backend });
                 Assert.IsTrue(example.HasValue);
                 Assert.AreEqual((short)257, example.Value);
                 Assert.AreEqual((byte)1, zf.Evaluate(257));
@@ -305,7 +305,7 @@ namespace ZenLib.Tests
 
             foreach (var backend in new SolverType[] { SolverType.Z3, SolverType.DecisionDiagrams })
             {
-                var example = zf.Find((s, b) => Zen.And(s == 257, b == 1), backend: backend);
+                var example = zf.Find((s, b) => Zen.And(s == 257, b == 1), config: new SolverConfig { SolverType = backend });
                 Assert.IsTrue(example.HasValue);
                 Assert.AreEqual((int)257, example.Value);
                 Assert.AreEqual((byte)1, zf.Evaluate(257));
@@ -322,7 +322,7 @@ namespace ZenLib.Tests
 
             foreach (var backend in new SolverType[] { SolverType.Z3, SolverType.DecisionDiagrams })
             {
-                var example = zf.Find((s, b) => Zen.And(s == 257, b == 1), backend: backend);
+                var example = zf.Find((s, b) => Zen.And(s == 257, b == 1), config: new SolverConfig { SolverType = backend });
                 Assert.IsTrue(example.HasValue);
                 Assert.AreEqual(257L, example.Value);
                 Assert.AreEqual((byte)1, zf.Evaluate(257));
@@ -339,7 +339,7 @@ namespace ZenLib.Tests
 
             foreach (var backend in new SolverType[] { SolverType.Z3, SolverType.DecisionDiagrams })
             {
-                var example = zf.Find((b, s) => Zen.And(b == 4, s == 4), backend: backend);
+                var example = zf.Find((b, s) => Zen.And(b == 4, s == 4), config: new SolverConfig { SolverType = backend });
                 Assert.IsTrue(example.HasValue);
                 Assert.AreEqual((byte)4, example.Value);
                 Assert.AreEqual((short)4, zf.Evaluate(4));
@@ -356,7 +356,7 @@ namespace ZenLib.Tests
 
             foreach (var backend in new SolverType[] { SolverType.Z3, SolverType.DecisionDiagrams })
             {
-                var example = zf.Find((u, s) => Zen.And(u == ushort.MaxValue, s == -1), backend: backend);
+                var example = zf.Find((u, s) => Zen.And(u == ushort.MaxValue, s == -1), config: new SolverConfig { SolverType = backend });
                 Assert.IsTrue(example.HasValue);
                 Assert.AreEqual(ushort.MaxValue, example.Value);
                 Assert.AreEqual((short)-1, zf.Evaluate(ushort.MaxValue));
@@ -373,7 +373,7 @@ namespace ZenLib.Tests
 
             foreach (var backend in new SolverType[] { SolverType.Z3, SolverType.DecisionDiagrams })
             {
-                var example = zf.Find((u, s) => u == new UInt<_16>(ushort.MaxValue), backend: backend);
+                var example = zf.Find((u, s) => u == new UInt<_16>(ushort.MaxValue), config: new SolverConfig { SolverType = backend });
                 Assert.IsTrue(example.HasValue);
                 Assert.AreEqual(new UInt<_16>(ushort.MaxValue), example.Value);
                 Assert.AreEqual((ulong)ushort.MaxValue, zf.Evaluate(new UInt<_16>(ushort.MaxValue)));
@@ -390,7 +390,7 @@ namespace ZenLib.Tests
 
             foreach (var backend in new SolverType[] { SolverType.Z3, SolverType.DecisionDiagrams })
             {
-                var example = zf.Find(backend: backend);
+                var example = zf.Find(config: new SolverConfig { SolverType = backend });
                 Assert.IsTrue(example.HasValue);
                 Assert.IsTrue(example.Value.ToLong() >= 4);
                 Assert.IsTrue(zf.Evaluate(example.Value));

--- a/ZenLib.Tests/FixedIntegerTests.cs
+++ b/ZenLib.Tests/FixedIntegerTests.cs
@@ -745,7 +745,7 @@ namespace ZenLib.Tests
             var b = new UInt<_128>(IPAddress.Parse("2000::").GetAddressBytes());
 
             var f = new ZenFunction<UInt<_128>, bool>(x => And(x >= a, x <= b));
-            var input = f.Find((x, y) => y, backend: SolverType.DecisionDiagrams);
+            var input = f.Find((x, y) => y, config: new SolverConfig { SolverType = SolverType.DecisionDiagrams });
 
             Assert.AreEqual(a, input.Value);
         }

--- a/ZenLib.Tests/PrimitiveTests.cs
+++ b/ZenLib.Tests/PrimitiveTests.cs
@@ -25,7 +25,7 @@ namespace ZenLib.Tests
         [TestMethod]
         public void TestNegatives()
         {
-            var result = Zen.Find<short>(x => -2 > -1, backend: SolverType.DecisionDiagrams);
+            var result = Zen.Find<short>(x => -2 > -1, config: new SolverConfig { SolverType = SolverType.DecisionDiagrams });
             Assert.IsFalse(result.HasValue);
         }
 
@@ -491,7 +491,7 @@ namespace ZenLib.Tests
         public void TestMultiplicationIntegers()
         {
             var f = new ZenFunction<int, int, bool>((a, b) => a * b == 10);
-            var inputs = f.Find((a, b, res) => res, backend: SolverType.Z3);
+            var inputs = f.Find((a, b, res) => res, config: new SolverConfig { SolverType = SolverType.Z3 });
             Assert.IsTrue(inputs.HasValue);
             Assert.AreEqual(10, inputs.Value.Item1 * inputs.Value.Item2);
 
@@ -513,7 +513,7 @@ namespace ZenLib.Tests
         public void TestMultiplicationReals()
         {
             var f = new ZenFunction<Real, bool>(a => (Real)2 * a == (Real)10);
-            var inputs = f.Find((a, res) => res, backend: SolverType.Z3);
+            var inputs = f.Find((a, res) => res, config: new SolverConfig { SolverType = SolverType.Z3 });
             Assert.IsTrue(inputs.HasValue);
             Assert.AreEqual(new Real(10), new Real(2) * inputs.Value);
 
@@ -547,7 +547,7 @@ namespace ZenLib.Tests
         public void TestMultiplicationException()
         {
             var f = new ZenFunction<int, int, bool>((a, b) => a * b == 10);
-            var inputs = f.Find((a, b, res) => res, backend: SolverType.DecisionDiagrams);
+            var inputs = f.Find((a, b, res) => res, config: new SolverConfig { SolverType = SolverType.DecisionDiagrams });
         }
 
         /// <summary>

--- a/ZenLib.Tests/StringTests.cs
+++ b/ZenLib.Tests/StringTests.cs
@@ -11,6 +11,7 @@ namespace ZenLib.Tests
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.Z3;
     using ZenLib;
+    using ZenLib.Solver;
     using static ZenLib.Tests.TestHelper;
     using static ZenLib.Zen;
 
@@ -642,7 +643,7 @@ namespace ZenLib.Tests
         public void TestDiagramBackendException1()
         {
             var f = new ZenFunction<string, bool>(s => s == "a");
-            f.Find((x, y) => y, backend: ZenLib.Solver.SolverType.DecisionDiagrams);
+            f.Find((x, y) => y, config: new SolverConfig { SolverType = ZenLib.Solver.SolverType.DecisionDiagrams });
         }
 
         /// <summary>
@@ -653,7 +654,7 @@ namespace ZenLib.Tests
         public void TestDiagramBackendException2()
         {
             var f = new ZenFunction<string, string>(s => s + "a");
-            f.Find((x, y) => x == y, backend: ZenLib.Solver.SolverType.DecisionDiagrams);
+            f.Find((x, y) => x == y, config: new SolverConfig { SolverType = ZenLib.Solver.SolverType.DecisionDiagrams });
         }
 
         /// <summary>

--- a/ZenLib.Tests/TestHelper.cs
+++ b/ZenLib.Tests/TestHelper.cs
@@ -138,11 +138,11 @@ namespace ZenLib.Tests
             {
                 // prove that it is valid
                 var f = Zen.Function<T1, bool>(function);
-                var result = f.Find((i1, o) => Flatten(Not(o), p), depth: p.FSeqSize, backend: p.SolverType);
+                var result = f.Find((i1, o) => Flatten(Not(o), p), depth: p.FSeqSize, config: new SolverConfig { SolverType = p.SolverType });
                 Assert.IsFalse(result.HasValue);
 
                 // compare input with evaluation
-                result = f.Find((i1, o) => o, depth: p.FSeqSize, backend: p.SolverType);
+                result = f.Find((i1, o) => o, depth: p.FSeqSize, config: new SolverConfig { SolverType = p.SolverType });
                 Assert.IsTrue(result.HasValue);
 
                 Assert.IsTrue(f.Evaluate(result.Value));
@@ -167,11 +167,11 @@ namespace ZenLib.Tests
             {
                 // prove that it is valid.
                 var f = Zen.Function<T1, T2, bool>(function);
-                var result = f.Find((i1, i2, o) => Flatten(Not(o), p), depth: p.FSeqSize, backend: p.SolverType);
+                var result = f.Find((i1, i2, o) => Flatten(Not(o), p), depth: p.FSeqSize, config: new SolverConfig { SolverType = p.SolverType });
                 Assert.IsFalse(result.HasValue);
 
                 // compare input with evaluation.
-                result = f.Find((i1, i2, o) => Flatten(o, p), depth: p.FSeqSize, backend: p.SolverType);
+                result = f.Find((i1, i2, o) => Flatten(o, p), depth: p.FSeqSize, config: new SolverConfig { SolverType = p.SolverType });
                 Assert.IsTrue(result.HasValue);
 
                 Assert.IsTrue(f.Evaluate(result.Value.Item1, result.Value.Item2));
@@ -196,11 +196,11 @@ namespace ZenLib.Tests
             {
                 // prove that it is valid
                 var f = Zen.Function<T1, T2, T3, bool>(function);
-                var result = f.Find((i1, i2, i3, o) => Flatten(Not(o), p), depth: p.FSeqSize, backend: p.SolverType);
+                var result = f.Find((i1, i2, i3, o) => Flatten(Not(o), p), depth: p.FSeqSize, config: new SolverConfig { SolverType = p.SolverType });
                 Assert.IsFalse(result.HasValue);
 
                 // compare input with evaluation
-                result = f.Find((i1, i2, i3, o) => Flatten(o, p), depth: p.FSeqSize, backend: p.SolverType);
+                result = f.Find((i1, i2, i3, o) => Flatten(o, p), depth: p.FSeqSize, config: new SolverConfig { SolverType = p.SolverType });
                 Assert.IsTrue(result.HasValue);
 
                 Assert.IsTrue(f.Evaluate(result.Value.Item1, result.Value.Item2, result.Value.Item3));
@@ -226,11 +226,11 @@ namespace ZenLib.Tests
             {
                 // prove that it is valid
                 var f = Zen.Function<T1, T2, T3, T4, bool>(function);
-                var result = f.Find((i1, i2, i3, i4, o) => Flatten(Not(o), p), depth: p.FSeqSize, backend: p.SolverType);
+                var result = f.Find((i1, i2, i3, i4, o) => Flatten(Not(o), p), depth: p.FSeqSize, config: new SolverConfig { SolverType = p.SolverType });
                 Assert.IsFalse(result.HasValue);
 
                 // compare input with evaluation
-                result = f.Find((i1, i2, i3, i4, o) => Flatten(o, p), depth: p.FSeqSize, backend: p.SolverType);
+                result = f.Find((i1, i2, i3, i4, o) => Flatten(o, p), depth: p.FSeqSize, config: new SolverConfig { SolverType = p.SolverType });
                 Assert.IsTrue(result.HasValue);
 
                 Assert.IsTrue(f.Evaluate(result.Value.Item1, result.Value.Item2, result.Value.Item3, result.Value.Item4));
@@ -253,7 +253,7 @@ namespace ZenLib.Tests
             {
                 // prove that it is not valid
                 var f = Zen.Function<T1, bool>(function);
-                var result = f.Find((i1, o) => Flatten(Not(o), p), depth: p.FSeqSize, backend: p.SolverType);
+                var result = f.Find((i1, o) => Flatten(Not(o), p), depth: p.FSeqSize, config: new SolverConfig { SolverType = p.SolverType });
                 Assert.IsTrue(result.HasValue);
 
                 // compare input with evaluation
@@ -277,7 +277,7 @@ namespace ZenLib.Tests
             foreach (var p in selectedParams)
             {
                 var f = Zen.Function<T1, T2, bool>(function);
-                var result = f.Find((i1, i2, o) => Flatten(Not(o), p), depth: p.FSeqSize, backend: p.SolverType);
+                var result = f.Find((i1, i2, o) => Flatten(Not(o), p), depth: p.FSeqSize, config: new SolverConfig { SolverType = p.SolverType });
                 Assert.IsTrue(result.HasValue);
 
                 // compare input with evaluation
@@ -297,7 +297,7 @@ namespace ZenLib.Tests
             foreach (var p in GetBoundedParameters(runBdds))
             {
                 var f = Zen.Function<bool>(function);
-                var result = f.Assert(o => Flatten(o, p), backend: p.SolverType);
+                var result = f.Assert(o => Flatten(o, p), config: new SolverConfig { SolverType = p.SolverType });
 
                 Assert.AreEqual(f.Evaluate(), result);
                 f.Compile();
@@ -317,7 +317,7 @@ namespace ZenLib.Tests
             foreach (var p in selectedParams)
             {
                 var f = Zen.Function<T1, bool>(function);
-                var result = f.Find((i1, o) => Flatten(o, p), depth: p.FSeqSize, backend: p.SolverType);
+                var result = f.Find((i1, o) => Flatten(o, p), depth: p.FSeqSize, config: new SolverConfig { SolverType = p.SolverType });
                 if (result.HasValue)
                 {
                     Assert.IsTrue(f.Evaluate(result.Value));
@@ -341,7 +341,7 @@ namespace ZenLib.Tests
             foreach (var p in selectedParams)
             {
                 var f = Zen.Function<T1, T2, bool>(function);
-                var result = f.Find((i1, i2, o) => Flatten(o, p), depth: p.FSeqSize, backend: p.SolverType);
+                var result = f.Find((i1, i2, o) => Flatten(o, p), depth: p.FSeqSize, config: new SolverConfig { SolverType = p.SolverType });
 
                 if (result.HasValue)
                 {

--- a/ZenLib.Tests/TimeoutTests.cs
+++ b/ZenLib.Tests/TimeoutTests.cs
@@ -25,6 +25,8 @@ namespace ZenLib.Tests
         [ExpectedException(typeof(ZenSolverTimeoutException))]
         public void TestTimeout()
         {
+            ZenSettings.UseLargeStack = true;
+
             var variables = new Zen<BigInteger>[2000];
 
             var constraints = new List<Zen<bool>>();

--- a/ZenLib.Tests/TimeoutTests.cs
+++ b/ZenLib.Tests/TimeoutTests.cs
@@ -1,0 +1,50 @@
+﻿// <copyright file="TimeoutTests.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace ZenLib.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Numerics;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using ZenLib.Solver;
+
+    /// <summary>
+    /// Tests that timeouts work with the solvers.
+    /// </summary>
+    [TestClass]
+    [ExcludeFromCodeCoverage]
+    public class TimeoutTests
+    {
+        /// <summary>
+        /// Test that a timeout works.
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(ZenSolverTimeoutException))]
+        public void TestTimeout()
+        {
+            var variables = new Zen<BigInteger>[2000];
+
+            var constraints = new List<Zen<bool>>();
+            var sum = Zen.Constant(BigInteger.Zero);
+            for (int i = 0; i < 2000; i++)
+            {
+                variables[i] = Zen.Symbolic<BigInteger>();
+                constraints.Add(variables[i] >= BigInteger.Zero);
+                sum += variables[i];
+            }
+            constraints.Add(sum == new BigInteger(3490));
+
+            // try to solve a big problem in a millisecond.
+            var solverConfig = new SolverConfig
+            {
+                SolverType = SolverType.Z3,
+                SolverTimeout = TimeSpan.FromMilliseconds(1),
+            };
+
+            Zen.And(constraints.ToArray()).Solve(solverConfig);
+        }
+    }
+}

--- a/ZenLib/Common/CommonUtilities.cs
+++ b/ZenLib/Common/CommonUtilities.cs
@@ -300,6 +300,11 @@ namespace ZenLib
             // propagate an internal exception
             if (exn != null)
             {
+                if (exn is ZenException || exn is ZenSolverTimeoutException)
+                {
+                    throw exn;
+                }
+
                 throw new ZenException("Execption thrown in RunWithLargeStack", exn);
             }
 

--- a/ZenLib/Common/ZenTimeoutException.cs
+++ b/ZenLib/Common/ZenTimeoutException.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="ZenSolverTimeoutException.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace ZenLib
+{
+    using System;
+
+    /// <summary>
+    /// New exception type for a timeout in a solver for Zen..
+    /// </summary>
+    public class ZenSolverTimeoutException : Exception
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="ZenSolverTimeoutException"/> class.
+        /// </summary>
+        public ZenSolverTimeoutException() : base()
+        {
+        }
+    }
+}

--- a/ZenLib/Language/Ast/Zen.cs
+++ b/ZenLib/Language/Ast/Zen.cs
@@ -1438,10 +1438,11 @@ namespace ZenLib
         /// </summary>
         /// <param name="expr">The boolean expression.</param>
         /// <param name="solverType">The solver type to use.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>Mapping from arbitrary expressions to C# objects.</returns>
-        public static ZenSolution Solve(this Zen<bool> expr, Solver.SolverType solverType = Solver.SolverType.Z3)
+        public static ZenSolution Solve(this Zen<bool> expr, Solver.SolverType solverType = Solver.SolverType.Z3, TimeSpan? timeout = null)
         {
-            var model = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(expr, new Dictionary<long, object>(), solverType));
+            var model = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(expr, new Dictionary<long, object>(), solverType, timeout));
             return new ZenSolution(model);
         }
 
@@ -1450,11 +1451,12 @@ namespace ZenLib
         /// </summary>
         /// <param name="objective">The objective function.</param>
         /// <param name="subjectTo">The boolean expression constraints.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>Mapping from arbitrary expressions to C# objects.</returns>
-        public static ZenSolution Maximize<T>(Zen<T> objective, Zen<bool> subjectTo)
+        public static ZenSolution Maximize<T>(Zen<T> objective, Zen<bool> subjectTo, TimeSpan? timeout = null)
         {
             Contract.Assert(ReflectionUtilities.IsArithmeticType(typeof(T)));
-            var model = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Maximize(objective, subjectTo, new Dictionary<long, object>(), Solver.SolverType.Z3));
+            var model = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Maximize(objective, subjectTo, new Dictionary<long, object>(), Solver.SolverType.Z3, timeout));
             return new ZenSolution(model);
         }
 
@@ -1463,11 +1465,12 @@ namespace ZenLib
         /// </summary>
         /// <param name="objective">The objective function.</param>
         /// <param name="subjectTo">The boolean expression constraints.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>Mapping from arbitrary expressions to C# objects.</returns>
-        public static ZenSolution Minimize<T>(Zen<T> objective, Zen<bool> subjectTo)
+        public static ZenSolution Minimize<T>(Zen<T> objective, Zen<bool> subjectTo, TimeSpan? timeout = null)
         {
             Contract.Assert(ReflectionUtilities.IsArithmeticType(typeof(T)));
-            var model = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Minimize(objective, subjectTo, new Dictionary<long, object>(), Solver.SolverType.Z3));
+            var model = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Minimize(objective, subjectTo, new Dictionary<long, object>(), Solver.SolverType.Z3, timeout));
             return new ZenSolution(model);
         }
 

--- a/ZenLib/Language/Ast/Zen.cs
+++ b/ZenLib/Language/Ast/Zen.cs
@@ -14,6 +14,7 @@ namespace ZenLib
     using ZenLib.Generation;
     using ZenLib.Interpretation;
     using ZenLib.ModelChecking;
+    using ZenLib.Solver;
 
     /// <summary>
     /// A Zen expression object parameterized over the C# type.
@@ -1437,12 +1438,12 @@ namespace ZenLib
         /// Solves for an assignment to Arbitrary variables in a boolean expression.
         /// </summary>
         /// <param name="expr">The boolean expression.</param>
-        /// <param name="solverType">The solver type to use.</param>
-        /// <param name="timeout">The optional solver timeout.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>Mapping from arbitrary expressions to C# objects.</returns>
-        public static ZenSolution Solve(this Zen<bool> expr, Solver.SolverType solverType = Solver.SolverType.Z3, TimeSpan? timeout = null)
+        public static ZenSolution Solve(this Zen<bool> expr, SolverConfig config = null)
         {
-            var model = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(expr, new Dictionary<long, object>(), solverType, timeout));
+            config = config ?? new SolverConfig();
+            var model = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(expr, new Dictionary<long, object>(), config));
             return new ZenSolution(model);
         }
 
@@ -1451,12 +1452,13 @@ namespace ZenLib
         /// </summary>
         /// <param name="objective">The objective function.</param>
         /// <param name="subjectTo">The boolean expression constraints.</param>
-        /// <param name="timeout">The optional solver timeout.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>Mapping from arbitrary expressions to C# objects.</returns>
-        public static ZenSolution Maximize<T>(Zen<T> objective, Zen<bool> subjectTo, TimeSpan? timeout = null)
+        public static ZenSolution Maximize<T>(Zen<T> objective, Zen<bool> subjectTo, SolverConfig config = null)
         {
             Contract.Assert(ReflectionUtilities.IsArithmeticType(typeof(T)));
-            var model = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Maximize(objective, subjectTo, new Dictionary<long, object>(), Solver.SolverType.Z3, timeout));
+            config = config ?? new SolverConfig();
+            var model = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Maximize(objective, subjectTo, new Dictionary<long, object>(), config));
             return new ZenSolution(model);
         }
 
@@ -1465,12 +1467,13 @@ namespace ZenLib
         /// </summary>
         /// <param name="objective">The objective function.</param>
         /// <param name="subjectTo">The boolean expression constraints.</param>
-        /// <param name="timeout">The optional solver timeout.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>Mapping from arbitrary expressions to C# objects.</returns>
-        public static ZenSolution Minimize<T>(Zen<T> objective, Zen<bool> subjectTo, TimeSpan? timeout = null)
+        public static ZenSolution Minimize<T>(Zen<T> objective, Zen<bool> subjectTo, SolverConfig config = null)
         {
             Contract.Assert(ReflectionUtilities.IsArithmeticType(typeof(T)));
-            var model = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Minimize(objective, subjectTo, new Dictionary<long, object>(), Solver.SolverType.Z3, timeout));
+            config = config ?? new SolverConfig();
+            var model = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Minimize(objective, subjectTo, new Dictionary<long, object>(), config));
             return new ZenSolution(model);
         }
 
@@ -1690,15 +1693,15 @@ namespace ZenLib
         /// <param name="invariant">The invariant.</param>
         /// <param name="input">The input.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
-        /// <param name="backend">The backend.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public static Option<T1> Find<T1>(
             Func<Zen<T1>, Zen<bool>> invariant,
             Zen<T1> input = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return Zen.Constraint<T1>(invariant).Find(input, depth, backend);
+            return Zen.Constraint<T1>(invariant).Find(input, depth, config);
         }
 
         /// <summary>
@@ -1708,16 +1711,16 @@ namespace ZenLib
         /// <param name="input1">The first input.</param>
         /// <param name="input2">The second input.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
-        /// <param name="backend">The backend.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public static Option<(T1, T2)> Find<T1, T2>(
             Func<Zen<T1>, Zen<T2>, Zen<bool>> invariant,
             Zen<T1> input1 = null,
             Zen<T2> input2 = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return Zen.Constraint<T1, T2>(invariant).Find(input1, input2, depth, backend);
+            return Zen.Constraint<T1, T2>(invariant).Find(input1, input2, depth, config);
         }
 
         /// <summary>
@@ -1728,7 +1731,7 @@ namespace ZenLib
         /// <param name="input2">The second input.</param>
         /// <param name="input3">The third input.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
-        /// <param name="backend">The backend.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public static Option<(T1, T2, T3)> Find<T1, T2, T3>(
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<bool>> invariant,
@@ -1736,9 +1739,9 @@ namespace ZenLib
             Zen<T2> input2 = null,
             Zen<T3> input3 = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return Zen.Constraint<T1, T2, T3>(invariant).Find(input1, input2, input3, depth, backend);
+            return Zen.Constraint<T1, T2, T3>(invariant).Find(input1, input2, input3, depth, config);
         }
 
         /// <summary>
@@ -1750,7 +1753,7 @@ namespace ZenLib
         /// <param name="input3">The third input.</param>
         /// <param name="input4">The fourth input.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
-        /// <param name="backend">The backend.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public static Option<(T1, T2, T3, T4)> Find<T1, T2, T3, T4>(
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<bool>> invariant,
@@ -1759,9 +1762,9 @@ namespace ZenLib
             Zen<T3> input3 = null,
             Zen<T4> input4 = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return Zen.Constraint<T1, T2, T3, T4>(invariant).Find(input1, input2, input3, input4, depth, backend);
+            return Zen.Constraint<T1, T2, T3, T4>(invariant).Find(input1, input2, input3, input4, depth, config);
         }
 
         /// <summary>
@@ -1770,15 +1773,15 @@ namespace ZenLib
         /// <param name="f">The Zen function.</param>
         /// <param name="precondition">The precondition.</param>
         /// <param name="depth">The maximum depth.</param>
-        /// <param name="backend">The backend solver.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>The input values.</returns>
         public static IEnumerable<T1> GenerateInputs<T1, T2>(
             Func<Zen<T1>, Zen<T2>> f,
             Func<Zen<T1>, Zen<bool>> precondition = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return new ZenFunction<T1, T2>(f).GenerateInputs(null, precondition, depth, backend);
+            return new ZenFunction<T1, T2>(f).GenerateInputs(null, precondition, depth, config);
         }
 
         /// <summary>
@@ -1787,15 +1790,15 @@ namespace ZenLib
         /// <param name="f">The Zen function.</param>
         /// <param name="precondition">The precondition.</param>
         /// <param name="depth">The maximum depth.</param>
-        /// <param name="backend">The backend solver.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>The input values.</returns>
         public static IEnumerable<(T1, T2)> GenerateInputs<T1, T2, T3>(
             Func<Zen<T1>, Zen<T2>, Zen<T3>> f,
             Func<Zen<T1>, Zen<T2>, Zen<bool>> precondition = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return new ZenFunction<T1, T2, T3>(f).GenerateInputs(null, null, precondition, depth, backend);
+            return new ZenFunction<T1, T2, T3>(f).GenerateInputs(null, null, precondition, depth, config);
         }
 
         /// <summary>
@@ -1804,15 +1807,15 @@ namespace ZenLib
         /// <param name="f">The Zen function.</param>
         /// <param name="precondition">The precondition.</param>
         /// <param name="depth">The maximum depth.</param>
-        /// <param name="backend">The backend solver.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>The input values.</returns>
         public static IEnumerable<(T1, T2, T3)> GenerateInputs<T1, T2, T3, T4>(
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>> f,
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<bool>> precondition = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return new ZenFunction<T1, T2, T3, T4>(f).GenerateInputs(null, null, null, precondition, depth, backend);
+            return new ZenFunction<T1, T2, T3, T4>(f).GenerateInputs(null, null, null, precondition, depth, config);
         }
 
         /// <summary>
@@ -1821,15 +1824,15 @@ namespace ZenLib
         /// <param name="f">The Zen function.</param>
         /// <param name="precondition">The precondition.</param>
         /// <param name="depth">The maximum depth.</param>
-        /// <param name="backend">The backend solver.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>The input values.</returns>
         public static IEnumerable<(T1, T2, T3, T4)> GenerateInputs<T1, T2, T3, T4, T5>(
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<T5>> f,
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<bool>> precondition = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return new ZenFunction<T1, T2, T3, T4, T5>(f).GenerateInputs(null, null, null, null, precondition, depth, backend);
+            return new ZenFunction<T1, T2, T3, T4, T5>(f).GenerateInputs(null, null, null, null, precondition, depth, config);
         }
 
         /// <summary>

--- a/ZenLib/Language/ZenConstraint.cs
+++ b/ZenLib/Language/ZenConstraint.cs
@@ -7,6 +7,7 @@ namespace ZenLib
     using System;
     using System.Collections.Generic;
     using ZenLib.ModelChecking;
+    using ZenLib.Solver;
 
     /// <summary>
     /// Zen constraint representation.
@@ -26,14 +27,14 @@ namespace ZenLib
         /// </summary>
         /// <param name="input">Default input that captures structural constraints.</param>
         /// <param name="depth">The maximum number of elements to consider in an input list.</param>
-        /// <param name="backend">The backend.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public Option<T> Find(
             Zen<T> input = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return Find((i, o) => o, input, depth, backend);
+            return Find((i, o) => o, input, depth, config);
         }
 
         /// <summary>
@@ -41,14 +42,14 @@ namespace ZenLib
         /// </summary>
         /// <param name="input">Default input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider.</param>
-        /// <param name="backend">The backend.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public IEnumerable<T> FindAll(
             Zen<T> input = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return FindAll((i, o) => o, input, depth, backend);
+            return FindAll((i, o) => o, input, depth, config);
         }
 
         /// <summary>
@@ -80,15 +81,15 @@ namespace ZenLib
         /// <param name="input1">First input that captures structural constraints.</param>
         /// <param name="input2">Second input that captures structural constraints.</param>
         /// <param name="depth">The maximum number of elements to consider in an input list.</param>
-        /// <param name="backend">The backend.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public Option<(T1, T2)> Find(
             Zen<T1> input1 = null,
             Zen<T2> input2 = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return Find((i1, i2, o) => o, input1, input2, depth, backend);
+            return Find((i1, i2, o) => o, input1, input2, depth, config);
         }
 
         /// <summary>
@@ -97,15 +98,15 @@ namespace ZenLib
         /// <param name="input1">First input that captures structural constraints.</param>
         /// <param name="input2">Second input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider.</param>
-        /// <param name="backend">The backend.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public IEnumerable<(T1, T2)> FindAll(
             Zen<T1> input1 = null,
             Zen<T2> input2 = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return FindAll((i1, i2, o) => o, input1, input2, depth, backend);
+            return FindAll((i1, i2, o) => o, input1, input2, depth, config);
         }
 
         /// <summary>
@@ -138,16 +139,16 @@ namespace ZenLib
         /// <param name="input2">Second input that captures structural constraints.</param>
         /// <param name="input3">Third input that captures structural constraints.</param>
         /// <param name="depth">The maximum number of elements to consider in an input list.</param>
-        /// <param name="backend">The backend.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public Option<(T1, T2, T3)> Find(
             Zen<T1> input1 = null,
             Zen<T2> input2 = null,
             Zen<T3> input3 = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return Find((i1, i2, i3, o) => o, input1, input2, input3, depth, backend);
+            return Find((i1, i2, i3, o) => o, input1, input2, input3, depth, config);
         }
 
         /// <summary>
@@ -157,16 +158,16 @@ namespace ZenLib
         /// <param name="input2">Second input that captures structural constraints.</param>
         /// <param name="input3">Third input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider.</param>
-        /// <param name="backend">The backend.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public IEnumerable<(T1, T2, T3)> FindAll(
             Zen<T1> input1 = null,
             Zen<T2> input2 = null,
             Zen<T3> input3 = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return FindAll((i1, i2, i3, o) => o, input1, input2, input3, depth, backend);
+            return FindAll((i1, i2, i3, o) => o, input1, input2, input3, depth, config);
         }
 
         /// <summary>
@@ -200,7 +201,7 @@ namespace ZenLib
         /// <param name="input3">Third input that captures structural constraints.</param>
         /// <param name="input4">Fourth input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider.</param>
-        /// <param name="backend">The backend.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public Option<(T1, T2, T3, T4)> Find(
             Zen<T1> input1 = null,
@@ -208,9 +209,9 @@ namespace ZenLib
             Zen<T3> input3 = null,
             Zen<T4> input4 = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return Find((i1, i2, i3, i4, o) => o, input1, input2, input3, input4, depth, backend);
+            return Find((i1, i2, i3, i4, o) => o, input1, input2, input3, input4, depth, config);
         }
 
         /// <summary>
@@ -221,7 +222,7 @@ namespace ZenLib
         /// <param name="input3">Third input that captures structural constraints.</param>
         /// <param name="input4">Fourth input that captures structural constraints.</param>
         /// <param name="depth">The maximum number of elements to consider in an input list.</param>
-        /// <param name="backend">The backend.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public IEnumerable<(T1, T2, T3, T4)> FindAll(
             Zen<T1> input1 = null,
@@ -229,9 +230,9 @@ namespace ZenLib
             Zen<T3> input3 = null,
             Zen<T4> input4 = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            SolverConfig config = null)
         {
-            return FindAll((i1, i2, i3, i4, o) => o, input1, input2, input3, input4, depth, backend);
+            return FindAll((i1, i2, i3, i4, o) => o, input1, input2, input3, input4, depth, config);
         }
 
         /// <summary>

--- a/ZenLib/Language/ZenFunction.cs
+++ b/ZenLib/Language/ZenFunction.cs
@@ -8,7 +8,6 @@ namespace ZenLib
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq.Expressions;
-    using ZenLib;
     using ZenLib.Compilation;
     using ZenLib.Interpretation;
     using ZenLib.ModelChecking;
@@ -93,11 +92,12 @@ namespace ZenLib
         /// </summary>
         /// <param name="invariant">The invariant.</param>
         /// <param name="backend">The backend.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
-        public bool Assert(Func<Zen<T>, Zen<bool>> invariant, Solver.SolverType backend = Solver.SolverType.Z3)
+        public bool Assert(Func<Zen<T>, Zen<bool>> invariant, Solver.SolverType backend = Solver.SolverType.Z3, TimeSpan? timeout = null)
         {
             var result = invariant(Function());
-            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, new Dictionary<long, object>(), backend) != null);
+            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, new Dictionary<long, object>(), backend, timeout) != null);
         }
     }
 
@@ -219,12 +219,14 @@ namespace ZenLib
         /// <param name="input">Default input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
         /// <param name="backend">The backend.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public Option<T1> Find(
             Func<Zen<T1>, Zen<T2>, Zen<bool>> invariant,
             Zen<T1> input = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            Solver.SolverType backend = Solver.SolverType.Z3,
+            TimeSpan? timeout = null)
         {
             input = CommonUtilities.GetArbitraryIfNull(input, depth);
             var args = new Dictionary<long, object>
@@ -233,7 +235,7 @@ namespace ZenLib
             };
 
             var result = invariant(Argument1, FunctionBodyExpr);
-            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input, backend));
+            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input, backend, timeout));
         }
 
         /// <summary>
@@ -243,12 +245,14 @@ namespace ZenLib
         /// <param name="input">Default input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
         /// <param name="backend">The backend.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public IEnumerable<T1> FindAll(
             Func<Zen<T1>, Zen<T2>, Zen<bool>> invariant,
             Zen<T1> input = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            Solver.SolverType backend = Solver.SolverType.Z3,
+            TimeSpan? timeout = null)
         {
             input = CommonUtilities.GetArbitraryIfNull(input, depth);
             var args = new Dictionary<long, object>
@@ -263,7 +267,7 @@ namespace ZenLib
             while (true)
             {
                 var expr = And(result, Not(blocking));
-                var example = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(expr, args, input, backend));
+                var example = CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(expr, args, input, backend, timeout));
                 if (!example.HasValue)
                 {
                     yield break;
@@ -281,16 +285,18 @@ namespace ZenLib
         /// <param name="input">Default input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
         /// <param name="backend">The backend.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public IEnumerable<T1> GenerateInputs(
             Zen<T1> input = null,
             Func<Zen<T1>, Zen<bool>> precondition = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            Solver.SolverType backend = Solver.SolverType.Z3,
+            TimeSpan? timeout = null)
         {
             input = CommonUtilities.GetArbitraryIfNull(input, depth);
             precondition = precondition == null ? (x) => true : precondition;
-            return CommonUtilities.RunWithLargeStack(() => InputGenerator.GenerateInputs(Function, precondition, input, backend));
+            return CommonUtilities.RunWithLargeStack(() => InputGenerator.GenerateInputs(Function, precondition, input, backend, timeout));
         }
     }
 
@@ -429,13 +435,15 @@ namespace ZenLib
         /// <param name="input2">Default second input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
         /// <param name="backend">The backend.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public Option<(T1, T2)> Find(
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<bool>> invariant,
             Zen<T1> input1 = null,
             Zen<T2> input2 = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            Solver.SolverType backend = Solver.SolverType.Z3,
+            TimeSpan? timeout = null)
         {
             input1 = CommonUtilities.GetArbitraryIfNull(input1, depth);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, depth);
@@ -446,7 +454,7 @@ namespace ZenLib
             };
 
             var result = invariant(Argument1, Argument2, FunctionBodyExpr);
-            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input1, input2, backend));
+            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input1, input2, backend, timeout));
         }
 
         /// <summary>
@@ -457,13 +465,15 @@ namespace ZenLib
         /// <param name="input2">Second input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
         /// <param name="backend">The backend.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public IEnumerable<(T1, T2)> FindAll(
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<bool>> invariant,
             Zen<T1> input1 = null,
             Zen<T2> input2 = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            Solver.SolverType backend = Solver.SolverType.Z3,
+            TimeSpan? timeout = null)
         {
             input1 = CommonUtilities.GetArbitraryIfNull(input1, depth);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, depth);
@@ -481,7 +491,7 @@ namespace ZenLib
             {
                 var expr = And(result, Not(blocking));
                 var example = CommonUtilities.RunWithLargeStack(
-                    () => SymbolicEvaluator.Find(expr, args, input1, input2, backend));
+                    () => SymbolicEvaluator.Find(expr, args, input1, input2, backend, timeout));
                 if (!example.HasValue)
                 {
                     yield break;
@@ -500,18 +510,20 @@ namespace ZenLib
         /// <param name="input2">Default second input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
         /// <param name="backend">The backend.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public IEnumerable<(T1, T2)> GenerateInputs(
             Zen<T1> input1 = null,
             Zen<T2> input2 = null,
             Func<Zen<T1>, Zen<T2>, Zen<bool>> precondition = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            Solver.SolverType backend = Solver.SolverType.Z3,
+            TimeSpan? timeout = null)
         {
             input1 = CommonUtilities.GetArbitraryIfNull(input1, depth);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, depth);
             precondition = precondition == null ? (x, y) => true : precondition;
-            return CommonUtilities.RunWithLargeStack(() => InputGenerator.GenerateInputs(Function, precondition, input1, input2, backend));
+            return CommonUtilities.RunWithLargeStack(() => InputGenerator.GenerateInputs(Function, precondition, input1, input2, backend, timeout));
         }
     }
 
@@ -662,6 +674,7 @@ namespace ZenLib
         /// <param name="input3">Default third input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
         /// <param name="backend">The backend.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public Option<(T1, T2, T3)> Find(
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<bool>> invariant,
@@ -669,7 +682,8 @@ namespace ZenLib
             Zen<T2> input2 = null,
             Zen<T3> input3 = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            Solver.SolverType backend = Solver.SolverType.Z3,
+            TimeSpan? timeout = null)
         {
             input1 = CommonUtilities.GetArbitraryIfNull(input1, depth);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, depth);
@@ -682,7 +696,7 @@ namespace ZenLib
             };
 
             var result = invariant(Argument1, Argument2, Argument3, FunctionBodyExpr);
-            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input1, input2, input3, backend));
+            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input1, input2, input3, backend, timeout));
         }
 
         /// <summary>
@@ -694,6 +708,7 @@ namespace ZenLib
         /// <param name="input3">Third input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
         /// <param name="backend">The backend.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public IEnumerable<(T1, T2, T3)> FindAll(
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<bool>> invariant,
@@ -701,7 +716,8 @@ namespace ZenLib
             Zen<T2> input2 = null,
             Zen<T3> input3 = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            Solver.SolverType backend = Solver.SolverType.Z3,
+            TimeSpan? timeout = null)
         {
             input1 = CommonUtilities.GetArbitraryIfNull(input1, depth);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, depth);
@@ -721,7 +737,7 @@ namespace ZenLib
             {
                 var expr = And(result, Not(blocking));
                 var example = CommonUtilities.RunWithLargeStack(
-                    () => SymbolicEvaluator.Find(expr, args, input1, input2, input3, backend));
+                    () => SymbolicEvaluator.Find(expr, args, input1, input2, input3, backend, timeout));
                 if (!example.HasValue)
                 {
                     yield break;
@@ -741,6 +757,7 @@ namespace ZenLib
         /// <param name="input3">Default third input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
         /// <param name="backend">The backend.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public IEnumerable<(T1, T2, T3)> GenerateInputs(
             Zen<T1> input1 = null,
@@ -748,13 +765,14 @@ namespace ZenLib
             Zen<T3> input3 = null,
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<bool>> precondition = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            Solver.SolverType backend = Solver.SolverType.Z3,
+            TimeSpan? timeout = null)
         {
             input1 = CommonUtilities.GetArbitraryIfNull(input1, depth);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, depth);
             input3 = CommonUtilities.GetArbitraryIfNull(input3, depth);
             precondition = precondition == null ? (x, y, z) => true : precondition;
-            return CommonUtilities.RunWithLargeStack(() => InputGenerator.GenerateInputs(Function, precondition, input1, input2, input3, backend));
+            return CommonUtilities.RunWithLargeStack(() => InputGenerator.GenerateInputs(Function, precondition, input1, input2, input3, backend, timeout));
         }
     }
 
@@ -917,6 +935,7 @@ namespace ZenLib
         /// <param name="input4">Default fourth input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
         /// <param name="backend">The backend.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public Option<(T1, T2, T3, T4)> Find(
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<T5>, Zen<bool>> invariant,
@@ -925,7 +944,8 @@ namespace ZenLib
             Zen<T3> input3 = null,
             Zen<T4> input4 = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            Solver.SolverType backend = Solver.SolverType.Z3,
+            TimeSpan? timeout = null)
         {
             input1 = CommonUtilities.GetArbitraryIfNull(input1, depth);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, depth);
@@ -940,7 +960,7 @@ namespace ZenLib
             };
 
             var result = invariant(Argument1, Argument2, Argument3, Argument4, FunctionBodyExpr);
-            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input1, input2, input3, input4, backend));
+            return CommonUtilities.RunWithLargeStack(() => SymbolicEvaluator.Find(result, args, input1, input2, input3, input4, backend, timeout));
         }
 
         /// <summary>
@@ -953,6 +973,7 @@ namespace ZenLib
         /// <param name="input4">Fourth input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
         /// <param name="backend">The backend.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public IEnumerable<(T1, T2, T3, T4)> FindAll(
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<T5>, Zen<bool>> invariant,
@@ -961,7 +982,8 @@ namespace ZenLib
             Zen<T3> input3 = null,
             Zen<T4> input4 = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            Solver.SolverType backend = Solver.SolverType.Z3,
+            TimeSpan? timeout = null)
         {
             input1 = CommonUtilities.GetArbitraryIfNull(input1, depth);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, depth);
@@ -983,7 +1005,7 @@ namespace ZenLib
             {
                 var expr = And(result, Not(blocking));
                 var example = CommonUtilities.RunWithLargeStack(
-                    () => SymbolicEvaluator.Find(expr, args, input1, input2, input3, input4, backend));
+                    () => SymbolicEvaluator.Find(expr, args, input1, input2, input3, input4, backend, timeout));
                 if (!example.HasValue)
                 {
                     yield break;
@@ -1004,6 +1026,7 @@ namespace ZenLib
         /// <param name="input4">Default fourth input that captures structural constraints.</param>
         /// <param name="depth">The maximum depth of elements to consider in an input.</param>
         /// <param name="backend">The backend.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>An input if one exists satisfying the constraints.</returns>
         public IEnumerable<(T1, T2, T3, T4)> GenerateInputs(
             Zen<T1> input1 = null,
@@ -1012,14 +1035,15 @@ namespace ZenLib
             Zen<T4> input4 = null,
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<bool>> precondition = null,
             int depth = 8,
-            Solver.SolverType backend = Solver.SolverType.Z3)
+            Solver.SolverType backend = Solver.SolverType.Z3,
+            TimeSpan? timeout = null)
         {
             input1 = CommonUtilities.GetArbitraryIfNull(input1, depth);
             input2 = CommonUtilities.GetArbitraryIfNull(input2, depth);
             input3 = CommonUtilities.GetArbitraryIfNull(input3, depth);
             input4 = CommonUtilities.GetArbitraryIfNull(input4, depth);
             precondition = precondition == null ? (w, x, y, z) => true : precondition;
-            return CommonUtilities.RunWithLargeStack(() => InputGenerator.GenerateInputs(Function, precondition, input1, input2, input3, input4, backend));
+            return CommonUtilities.RunWithLargeStack(() => InputGenerator.GenerateInputs(Function, precondition, input1, input2, input3, input4, backend, timeout));
         }
     }
 }

--- a/ZenLib/ModelChecking/Backend/ModelCheckerFactory.cs
+++ b/ZenLib/ModelChecking/Backend/ModelCheckerFactory.cs
@@ -19,20 +19,19 @@ namespace ZenLib.ModelChecking
         /// <summary>
         /// Create a model checker.
         /// </summary>
-        /// <param name="backend">The backend to use.</param>
+        /// <param name="config">The solver configuration to use.</param>
         /// <param name="context">The checking context.</param>
         /// <param name="expression">The expression to evaluate.</param>
         /// <param name="arguments">The arguements.</param>
-        /// <param name="timeout">An optional timeout on the solver.</param>
         /// <returns>A new model checker.</returns>
-        internal static IModelChecker CreateModelChecker(SolverType backend, ModelCheckerContext context, Zen<bool> expression, Dictionary<long, object> arguments, TimeSpan? timeout)
+        internal static IModelChecker CreateModelChecker(SolverConfig config, ModelCheckerContext context, Zen<bool> expression, Dictionary<long, object> arguments)
         {
-            if (backend == SolverType.DecisionDiagrams)
+            if (config.SolverType == SolverType.DecisionDiagrams)
             {
                 return CreateModelCheckerDD(expression, arguments);
             }
 
-            return CreateModelCheckerZ3(context, timeout);
+            return CreateModelCheckerZ3(context, config.SolverTimeout);
         }
 
         /// <summary>

--- a/ZenLib/ModelChecking/Backend/ModelCheckerFactory.cs
+++ b/ZenLib/ModelChecking/Backend/ModelCheckerFactory.cs
@@ -4,6 +4,7 @@
 
 namespace ZenLib.ModelChecking
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using DecisionDiagrams;
@@ -22,15 +23,16 @@ namespace ZenLib.ModelChecking
         /// <param name="context">The checking context.</param>
         /// <param name="expression">The expression to evaluate.</param>
         /// <param name="arguments">The arguements.</param>
+        /// <param name="timeout">An optional timeout on the solver.</param>
         /// <returns>A new model checker.</returns>
-        internal static IModelChecker CreateModelChecker(SolverType backend, ModelCheckerContext context, Zen<bool> expression, Dictionary<long, object> arguments)
+        internal static IModelChecker CreateModelChecker(SolverType backend, ModelCheckerContext context, Zen<bool> expression, Dictionary<long, object> arguments, TimeSpan? timeout)
         {
             if (backend == SolverType.DecisionDiagrams)
             {
                 return CreateModelCheckerDD(expression, arguments);
             }
 
-            return CreateModelCheckerZ3(context);
+            return CreateModelCheckerZ3(context, timeout);
         }
 
         /// <summary>
@@ -54,10 +56,11 @@ namespace ZenLib.ModelChecking
         /// Create a model checker based on SMT with Z3.
         /// </summary>
         /// <param name="context">The model checker context.</param>
+        /// <param name="timeout">A solver timeout parameter.</param>
         /// <returns>A model checker.</returns>
-        private static IModelChecker CreateModelCheckerZ3(ModelCheckerContext context)
+        private static IModelChecker CreateModelCheckerZ3(ModelCheckerContext context, TimeSpan? timeout)
         {
-            return new ModelChecker<Model, Expr, BoolExpr, BitVecExpr, IntExpr, SeqExpr, ArrayExpr, Expr, RealExpr>(new SolverZ3(context));
+            return new ModelChecker<Model, Expr, BoolExpr, BitVecExpr, IntExpr, SeqExpr, ArrayExpr, Expr, RealExpr>(new SolverZ3(context, timeout));
         }
     }
 }

--- a/ZenLib/ModelChecking/Backend/SymbolicEvaluator.cs
+++ b/ZenLib/ModelChecking/Backend/SymbolicEvaluator.cs
@@ -4,6 +4,7 @@
 
 namespace ZenLib.ModelChecking
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using ZenLib.Interpretation;
@@ -20,10 +21,11 @@ namespace ZenLib.ModelChecking
         /// <param name="expression">The Zen expression for the function.</param>
         /// <param name="arguments">The arguments.</param>
         /// <param name="backend">The backend to use.</param>
+        /// <param name="timeout">The optional timeout for the solver.</param>
         /// <returns>True or false.</returns>
-        public static Dictionary<object, object> Find(Zen<bool> expression, Dictionary<long, object> arguments, SolverType backend)
+        public static Dictionary<object, object> Find(Zen<bool> expression, Dictionary<long, object> arguments, SolverType backend, TimeSpan? timeout)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, expression, arguments);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, expression, arguments, timeout);
             return modelChecker.ModelCheck(expression, arguments);
         }
 
@@ -34,10 +36,11 @@ namespace ZenLib.ModelChecking
         /// <param name="subjectTo">The constraints.</param>
         /// <param name="arguments">The arguments.</param>
         /// <param name="backend">The backend to use.</param>
+        /// <param name="timeout">The optional timeout for the solver.</param>
         /// <returns>True or false.</returns>
-        public static Dictionary<object, object> Maximize<T>(Zen<T> objective, Zen<bool> subjectTo, Dictionary<long, object> arguments, SolverType backend)
+        public static Dictionary<object, object> Maximize<T>(Zen<T> objective, Zen<bool> subjectTo, Dictionary<long, object> arguments, SolverType backend, TimeSpan? timeout)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Optimization, null, arguments);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Optimization, null, arguments, timeout);
             return modelChecker.Maximize(objective, subjectTo, arguments);
         }
 
@@ -48,10 +51,11 @@ namespace ZenLib.ModelChecking
         /// <param name="subjectTo">The constraints.</param>
         /// <param name="arguments">The arguments.</param>
         /// <param name="backend">The backend to use.</param>
+        /// <param name="timeout">The optional timeout for the solver.</param>
         /// <returns>True or false.</returns>
-        public static Dictionary<object, object> Minimize<T>(Zen<T> objective, Zen<bool> subjectTo, Dictionary<long, object> arguments, SolverType backend)
+        public static Dictionary<object, object> Minimize<T>(Zen<T> objective, Zen<bool> subjectTo, Dictionary<long, object> arguments, SolverType backend, TimeSpan? timeout)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Optimization, null, arguments);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Optimization, null, arguments, timeout);
             return modelChecker.Minimize(objective, subjectTo, arguments);
         }
 
@@ -62,14 +66,16 @@ namespace ZenLib.ModelChecking
         /// <param name="arguments">The arguments.</param>
         /// <param name="input">The Zen expression for the input to the function.</param>
         /// <param name="backend">The backend to use.</param>
+        /// <param name="timeout">The optional timeout for the solver.</param>
         /// <returns>An optional input value.</returns>
         public static Option<T> Find<T>(
             Zen<bool> expression,
             Dictionary<long, object> arguments,
             Zen<T> input,
-            SolverType backend)
+            SolverType backend,
+            TimeSpan? timeout)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, expression, arguments);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, expression, arguments, timeout);
             var assignment = modelChecker.ModelCheck(expression, arguments);
             if (assignment == null)
             {
@@ -90,15 +96,17 @@ namespace ZenLib.ModelChecking
         /// <param name="input1">The first Zen expression for the input to the function.</param>
         /// <param name="input2">The second Zen expression for the input to the function.</param>
         /// <param name="backend">The backend to use.</param>
+        /// <param name="timeout">The optional timeout for the solver.</param>
         /// <returns>An optional input value.</returns>
         public static Option<(T1, T2)> Find<T1, T2>(
             Zen<bool> expression,
             Dictionary<long, object> arguments,
             Zen<T1> input1,
             Zen<T2> input2,
-            SolverType backend)
+            SolverType backend,
+            TimeSpan? timeout)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, expression, arguments);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, expression, arguments, timeout);
 
             var assignment = modelChecker.ModelCheck(expression, arguments);
 
@@ -123,6 +131,7 @@ namespace ZenLib.ModelChecking
         /// <param name="input2">The second Zen expression for the input to the function.</param>
         /// <param name="input3">The third Zen expression for the input to the function.</param>
         /// <param name="backend">The backend to use.</param>
+        /// <param name="timeout">The optional timeout for the solver.</param>
         /// <returns>An optional input value.</returns>
         public static Option<(T1, T2, T3)> Find<T1, T2, T3>(
             Zen<bool> expression,
@@ -130,9 +139,10 @@ namespace ZenLib.ModelChecking
             Zen<T1> input1,
             Zen<T2> input2,
             Zen<T3> input3,
-            SolverType backend)
+            SolverType backend,
+            TimeSpan? timeout)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, expression, arguments);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, expression, arguments, timeout);
             var assignment = modelChecker.ModelCheck(expression, arguments);
 
             if (assignment == null)
@@ -158,6 +168,7 @@ namespace ZenLib.ModelChecking
         /// <param name="input3">The third Zen expression for the input to the function.</param>
         /// <param name="input4">The fourth Zen expression for the input to the function.</param>
         /// <param name="backend">The backend to use.</param>
+        /// <param name="timeout">The optional timeout for the solver.</param>
         /// <returns>An optional input value.</returns>
         public static Option<(T1, T2, T3, T4)> Find<T1, T2, T3, T4>(
             Zen<bool> expression,
@@ -166,9 +177,10 @@ namespace ZenLib.ModelChecking
             Zen<T2> input2,
             Zen<T3> input3,
             Zen<T4> input4,
-            SolverType backend)
+            SolverType backend,
+            TimeSpan? timeout)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, expression, arguments);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, expression, arguments, timeout);
             var assignment = modelChecker.ModelCheck(expression, arguments);
 
             if (assignment == null)

--- a/ZenLib/ModelChecking/Backend/SymbolicEvaluator.cs
+++ b/ZenLib/ModelChecking/Backend/SymbolicEvaluator.cs
@@ -20,12 +20,11 @@ namespace ZenLib.ModelChecking
         /// </summary>
         /// <param name="expression">The Zen expression for the function.</param>
         /// <param name="arguments">The arguments.</param>
-        /// <param name="backend">The backend to use.</param>
-        /// <param name="timeout">The optional timeout for the solver.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>True or false.</returns>
-        public static Dictionary<object, object> Find(Zen<bool> expression, Dictionary<long, object> arguments, SolverType backend, TimeSpan? timeout)
+        public static Dictionary<object, object> Find(Zen<bool> expression, Dictionary<long, object> arguments, SolverConfig config)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, expression, arguments, timeout);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(config, ModelCheckerContext.Solving, expression, arguments);
             return modelChecker.ModelCheck(expression, arguments);
         }
 
@@ -35,12 +34,11 @@ namespace ZenLib.ModelChecking
         /// <param name="objective">The objective.</param>
         /// <param name="subjectTo">The constraints.</param>
         /// <param name="arguments">The arguments.</param>
-        /// <param name="backend">The backend to use.</param>
-        /// <param name="timeout">The optional timeout for the solver.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>True or false.</returns>
-        public static Dictionary<object, object> Maximize<T>(Zen<T> objective, Zen<bool> subjectTo, Dictionary<long, object> arguments, SolverType backend, TimeSpan? timeout)
+        public static Dictionary<object, object> Maximize<T>(Zen<T> objective, Zen<bool> subjectTo, Dictionary<long, object> arguments, SolverConfig config)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Optimization, null, arguments, timeout);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(config, ModelCheckerContext.Optimization, null, arguments);
             return modelChecker.Maximize(objective, subjectTo, arguments);
         }
 
@@ -50,12 +48,11 @@ namespace ZenLib.ModelChecking
         /// <param name="objective">The objective.</param>
         /// <param name="subjectTo">The constraints.</param>
         /// <param name="arguments">The arguments.</param>
-        /// <param name="backend">The backend to use.</param>
-        /// <param name="timeout">The optional timeout for the solver.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>True or false.</returns>
-        public static Dictionary<object, object> Minimize<T>(Zen<T> objective, Zen<bool> subjectTo, Dictionary<long, object> arguments, SolverType backend, TimeSpan? timeout)
+        public static Dictionary<object, object> Minimize<T>(Zen<T> objective, Zen<bool> subjectTo, Dictionary<long, object> arguments, SolverConfig config)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Optimization, null, arguments, timeout);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(config, ModelCheckerContext.Optimization, null, arguments);
             return modelChecker.Minimize(objective, subjectTo, arguments);
         }
 
@@ -65,17 +62,15 @@ namespace ZenLib.ModelChecking
         /// <param name="expression">The Zen expression for the function.</param>
         /// <param name="arguments">The arguments.</param>
         /// <param name="input">The Zen expression for the input to the function.</param>
-        /// <param name="backend">The backend to use.</param>
-        /// <param name="timeout">The optional timeout for the solver.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An optional input value.</returns>
         public static Option<T> Find<T>(
             Zen<bool> expression,
             Dictionary<long, object> arguments,
             Zen<T> input,
-            SolverType backend,
-            TimeSpan? timeout)
+            SolverConfig config)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, expression, arguments, timeout);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(config, ModelCheckerContext.Solving, expression, arguments);
             var assignment = modelChecker.ModelCheck(expression, arguments);
             if (assignment == null)
             {
@@ -95,18 +90,16 @@ namespace ZenLib.ModelChecking
         /// <param name="arguments">The arguments.</param>
         /// <param name="input1">The first Zen expression for the input to the function.</param>
         /// <param name="input2">The second Zen expression for the input to the function.</param>
-        /// <param name="backend">The backend to use.</param>
-        /// <param name="timeout">The optional timeout for the solver.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An optional input value.</returns>
         public static Option<(T1, T2)> Find<T1, T2>(
             Zen<bool> expression,
             Dictionary<long, object> arguments,
             Zen<T1> input1,
             Zen<T2> input2,
-            SolverType backend,
-            TimeSpan? timeout)
+            SolverConfig config)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, expression, arguments, timeout);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(config, ModelCheckerContext.Solving, expression, arguments);
 
             var assignment = modelChecker.ModelCheck(expression, arguments);
 
@@ -130,8 +123,7 @@ namespace ZenLib.ModelChecking
         /// <param name="input1">The first Zen expression for the input to the function.</param>
         /// <param name="input2">The second Zen expression for the input to the function.</param>
         /// <param name="input3">The third Zen expression for the input to the function.</param>
-        /// <param name="backend">The backend to use.</param>
-        /// <param name="timeout">The optional timeout for the solver.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An optional input value.</returns>
         public static Option<(T1, T2, T3)> Find<T1, T2, T3>(
             Zen<bool> expression,
@@ -139,10 +131,9 @@ namespace ZenLib.ModelChecking
             Zen<T1> input1,
             Zen<T2> input2,
             Zen<T3> input3,
-            SolverType backend,
-            TimeSpan? timeout)
+            SolverConfig config)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, expression, arguments, timeout);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(config, ModelCheckerContext.Solving, expression, arguments);
             var assignment = modelChecker.ModelCheck(expression, arguments);
 
             if (assignment == null)
@@ -167,8 +158,7 @@ namespace ZenLib.ModelChecking
         /// <param name="input2">The second Zen expression for the input to the function.</param>
         /// <param name="input3">The third Zen expression for the input to the function.</param>
         /// <param name="input4">The fourth Zen expression for the input to the function.</param>
-        /// <param name="backend">The backend to use.</param>
-        /// <param name="timeout">The optional timeout for the solver.</param>
+        /// <param name="config">The solver configuration.</param>
         /// <returns>An optional input value.</returns>
         public static Option<(T1, T2, T3, T4)> Find<T1, T2, T3, T4>(
             Zen<bool> expression,
@@ -177,10 +167,9 @@ namespace ZenLib.ModelChecking
             Zen<T2> input2,
             Zen<T3> input3,
             Zen<T4> input4,
-            SolverType backend,
-            TimeSpan? timeout)
+            SolverConfig config)
         {
-            var modelChecker = ModelCheckerFactory.CreateModelChecker(backend, ModelCheckerContext.Solving, expression, arguments, timeout);
+            var modelChecker = ModelCheckerFactory.CreateModelChecker(config, ModelCheckerContext.Solving, expression, arguments);
             var assignment = modelChecker.ModelCheck(expression, arguments);
 
             if (assignment == null)

--- a/ZenLib/Solver/SolverConfig.cs
+++ b/ZenLib/Solver/SolverConfig.cs
@@ -1,0 +1,24 @@
+﻿// <copyright file="SolverConfig.cs" company="Microsoft">
+// Copyright (c) Microsoft. All rights reserved.
+// </copyright>
+
+namespace ZenLib.Solver
+{
+    using System;
+
+    /// <summary>
+    /// Solver configuration for Zen.
+    /// </summary>
+    public class SolverConfig
+    {
+        /// <summary>
+        /// The solver type to use.
+        /// </summary>
+        public SolverType SolverType { get; set; } = SolverType.Z3;
+
+        /// <summary>
+        /// The solver timeout to use.
+        /// </summary>
+        public TimeSpan? SolverTimeout { get; set; } = null;
+    }
+}

--- a/ZenLib/Solver/SolverZ3.cs
+++ b/ZenLib/Solver/SolverZ3.cs
@@ -147,7 +147,7 @@ namespace ZenLib.Solver
             this.Params.Add("compact", false);
             if (timeout.HasValue)
             {
-                this.Params.Add("timeout", timeout.Value.TotalMilliseconds);
+                this.Params.Add("timeout", (uint)timeout.Value.TotalMilliseconds);
             }
             var t1 = Context.MkTactic("simplify");
             var t2 = Context.MkTactic("solve-eqs");

--- a/ZenLib/SymbolicExecution/InputGenerator.cs
+++ b/ZenLib/SymbolicExecution/InputGenerator.cs
@@ -27,28 +27,26 @@ namespace ZenLib.SymbolicExecution
         /// <param name="function">The function.</param>
         /// <param name="precondition">A precondition.</param>
         /// <param name="input">The symbolic input.</param>
-        /// <param name="solverType">The solver to use.</param>
-        /// <param name="timeout">The optional solver timeout.</param>
+        /// <param name="config">The solver configuration to use.</param>
         /// <returns>A collection of inputs.</returns>
         public static IEnumerable<T1> GenerateInputs<T1, T2>(
             Func<Zen<T1>, Zen<T2>> function,
             Func<Zen<T1>, Zen<bool>> precondition,
             Zen<T1> input,
-            SolverType solverType,
-            TimeSpan? timeout)
+            SolverConfig config)
         {
             var expression = function(input);
             var assume = precondition(input);
 
             (T2, PathConstraint, Dictionary<long, object>) interpretFunction(T1 e)
             {
-                var assignment = ModelCheckerFactory.CreateModelChecker(solverType, ModelCheckerContext.Solving, null, emptyArguments, timeout).ModelCheck(input == e, emptyArguments);
+                var assignment = ModelCheckerFactory.CreateModelChecker(config, ModelCheckerContext.Solving, null, emptyArguments).ModelCheck(input == e, emptyArguments);
                 var evaluator = new ExpressionEvaluatorVisitor(true);
                 var env = new ExpressionEvaluatorEnvironment { ArbitraryAssignment = System.Collections.Immutable.ImmutableDictionary<object, object>.Empty.AddRange(assignment) };
                 return ((T2)evaluator.Visit(expression, env), evaluator.PathConstraint, evaluator.PathConstraintSymbolicEnvironment);
             }
 
-            Option<T1> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input, solverType, timeout);
+            Option<T1> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input, config);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }
@@ -60,16 +58,14 @@ namespace ZenLib.SymbolicExecution
         /// <param name="precondition">A precondition for inputs.</param>
         /// <param name="input1">The first symbolic input.</param>
         /// <param name="input2">The second symbolic input.</param>
-        /// <param name="solverType">The solver to use.</param>
-        /// <param name="timeout">The optional solver timeout.</param>
+        /// <param name="config">The solver configuration to use.</param>
         /// <returns>A collection of inputs.</returns>
         public static IEnumerable<(T1, T2)> GenerateInputs<T1, T2, T3>(
             Func<Zen<T1>, Zen<T2>, Zen<T3>> function,
             Func<Zen<T1>, Zen<T2>, Zen<bool>> precondition,
             Zen<T1> input1,
             Zen<T2> input2,
-            SolverType solverType,
-            TimeSpan? timeout)
+            SolverConfig config)
         {
             var expression = function(input1, input2);
             var assume = precondition(input1, input2);
@@ -77,14 +73,14 @@ namespace ZenLib.SymbolicExecution
             (T3, PathConstraint, Dictionary<long, object>) interpretFunction((T1, T2) e)
             {
                 var assignment = ModelCheckerFactory
-                    .CreateModelChecker(solverType, ModelCheckerContext.Solving, null, emptyArguments, timeout)
+                    .CreateModelChecker(config, ModelCheckerContext.Solving, null, emptyArguments)
                     .ModelCheck(And(input1 == e.Item1, input2 == e.Item2), emptyArguments);
                 var evaluator = new ExpressionEvaluatorVisitor(true);
                 var env = new ExpressionEvaluatorEnvironment { ArbitraryAssignment = System.Collections.Immutable.ImmutableDictionary<object, object>.Empty.AddRange(assignment) };
                 return ((T3)evaluator.Visit(expression, env), evaluator.PathConstraint, evaluator.PathConstraintSymbolicEnvironment);
             }
 
-            Option<(T1, T2)> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input1, input2, solverType, timeout);
+            Option<(T1, T2)> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input1, input2, config);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }
@@ -97,8 +93,7 @@ namespace ZenLib.SymbolicExecution
         /// <param name="input1">The first symbolic input.</param>
         /// <param name="input2">The second symbolic input.</param>
         /// <param name="input3">The third symbolic input.</param>
-        /// <param name="solverType">The solver to use.</param>
-        /// <param name="timeout">The optional solver timeout.</param>
+        /// <param name="config">The solver configuration to use.</param>
         /// <returns>A collection of inputs.</returns>
         public static IEnumerable<(T1, T2, T3)> GenerateInputs<T1, T2, T3, T4>(
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>> function,
@@ -106,8 +101,7 @@ namespace ZenLib.SymbolicExecution
             Zen<T1> input1,
             Zen<T2> input2,
             Zen<T3> input3,
-            SolverType solverType,
-            TimeSpan? timeout)
+            SolverConfig config)
         {
             var expression = function(input1, input2, input3);
             var assume = precondition(input1, input2, input3);
@@ -115,14 +109,14 @@ namespace ZenLib.SymbolicExecution
             (T4, PathConstraint, Dictionary<long, object>) interpretFunction((T1, T2, T3) e)
             {
                 var assignment = ModelCheckerFactory
-                    .CreateModelChecker(solverType, ModelCheckerContext.Solving, null, emptyArguments, timeout)
+                    .CreateModelChecker(config, ModelCheckerContext.Solving, null, emptyArguments)
                     .ModelCheck(And(input1 == e.Item1, input2 == e.Item2, input3 == e.Item3), emptyArguments);
                 var evaluator = new ExpressionEvaluatorVisitor(true);
                 var env = new ExpressionEvaluatorEnvironment { ArbitraryAssignment = System.Collections.Immutable.ImmutableDictionary<object, object>.Empty.AddRange(assignment) };
                 return ((T4)evaluator.Visit(expression, env), evaluator.PathConstraint, evaluator.PathConstraintSymbolicEnvironment);
             }
 
-            Option<(T1, T2, T3)> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input1, input2, input3, solverType, timeout);
+            Option<(T1, T2, T3)> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input1, input2, input3, config);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }
@@ -136,8 +130,7 @@ namespace ZenLib.SymbolicExecution
         /// <param name="input2">The second symbolic input.</param>
         /// <param name="input3">The third symbolic input.</param>
         /// <param name="input4">The fourth symbolic input.</param>
-        /// <param name="solverType">The solver to use.</param>
-        /// <param name="timeout">The optional solver timeout.</param>
+        /// <param name="config">The solver configuration to use.</param>
         /// <returns>A collection of inputs.</returns>
         public static IEnumerable<(T1, T2, T3, T4)> GenerateInputs<T1, T2, T3, T4, T5>(
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<T5>> function,
@@ -146,8 +139,7 @@ namespace ZenLib.SymbolicExecution
             Zen<T2> input2,
             Zen<T3> input3,
             Zen<T4> input4,
-            SolverType solverType,
-            TimeSpan? timeout)
+            SolverConfig config)
         {
             var expression = function(input1, input2, input3, input4);
             var assume = precondition(input1, input2, input3, input4);
@@ -155,14 +147,14 @@ namespace ZenLib.SymbolicExecution
             (T5, PathConstraint, Dictionary<long, object>) interpretFunction((T1, T2, T3, T4) e)
             {
                 var assignment = ModelCheckerFactory
-                    .CreateModelChecker(solverType, ModelCheckerContext.Solving, null, emptyArguments, timeout)
+                    .CreateModelChecker(config, ModelCheckerContext.Solving, null, emptyArguments)
                     .ModelCheck(And(input1 == e.Item1, input2 == e.Item2, input3 == e.Item3, input4 == e.Item4), emptyArguments);
                 var evaluator = new ExpressionEvaluatorVisitor(true);
                 var env = new ExpressionEvaluatorEnvironment { ArbitraryAssignment = System.Collections.Immutable.ImmutableDictionary<object, object>.Empty.AddRange(assignment) };
                 return ((T5)evaluator.Visit(expression, env), evaluator.PathConstraint, evaluator.PathConstraintSymbolicEnvironment);
             }
 
-            Option<(T1, T2, T3, T4)> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input1, input2, input3, input4, solverType, timeout);
+            Option<(T1, T2, T3, T4)> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input1, input2, input3, input4, config);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }

--- a/ZenLib/SymbolicExecution/InputGenerator.cs
+++ b/ZenLib/SymbolicExecution/InputGenerator.cs
@@ -28,25 +28,27 @@ namespace ZenLib.SymbolicExecution
         /// <param name="precondition">A precondition.</param>
         /// <param name="input">The symbolic input.</param>
         /// <param name="solverType">The solver to use.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>A collection of inputs.</returns>
         public static IEnumerable<T1> GenerateInputs<T1, T2>(
             Func<Zen<T1>, Zen<T2>> function,
             Func<Zen<T1>, Zen<bool>> precondition,
             Zen<T1> input,
-            SolverType solverType)
+            SolverType solverType,
+            TimeSpan? timeout)
         {
             var expression = function(input);
             var assume = precondition(input);
 
             (T2, PathConstraint, Dictionary<long, object>) interpretFunction(T1 e)
             {
-                var assignment = ModelCheckerFactory.CreateModelChecker(solverType, ModelCheckerContext.Solving, null, emptyArguments).ModelCheck(input == e, emptyArguments);
+                var assignment = ModelCheckerFactory.CreateModelChecker(solverType, ModelCheckerContext.Solving, null, emptyArguments, timeout).ModelCheck(input == e, emptyArguments);
                 var evaluator = new ExpressionEvaluatorVisitor(true);
                 var env = new ExpressionEvaluatorEnvironment { ArbitraryAssignment = System.Collections.Immutable.ImmutableDictionary<object, object>.Empty.AddRange(assignment) };
                 return ((T2)evaluator.Visit(expression, env), evaluator.PathConstraint, evaluator.PathConstraintSymbolicEnvironment);
             }
 
-            Option<T1> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input, solverType);
+            Option<T1> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input, solverType, timeout);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }
@@ -59,13 +61,15 @@ namespace ZenLib.SymbolicExecution
         /// <param name="input1">The first symbolic input.</param>
         /// <param name="input2">The second symbolic input.</param>
         /// <param name="solverType">The solver to use.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>A collection of inputs.</returns>
         public static IEnumerable<(T1, T2)> GenerateInputs<T1, T2, T3>(
             Func<Zen<T1>, Zen<T2>, Zen<T3>> function,
             Func<Zen<T1>, Zen<T2>, Zen<bool>> precondition,
             Zen<T1> input1,
             Zen<T2> input2,
-            SolverType solverType)
+            SolverType solverType,
+            TimeSpan? timeout)
         {
             var expression = function(input1, input2);
             var assume = precondition(input1, input2);
@@ -73,14 +77,14 @@ namespace ZenLib.SymbolicExecution
             (T3, PathConstraint, Dictionary<long, object>) interpretFunction((T1, T2) e)
             {
                 var assignment = ModelCheckerFactory
-                    .CreateModelChecker(solverType, ModelCheckerContext.Solving, null, emptyArguments)
+                    .CreateModelChecker(solverType, ModelCheckerContext.Solving, null, emptyArguments, timeout)
                     .ModelCheck(And(input1 == e.Item1, input2 == e.Item2), emptyArguments);
                 var evaluator = new ExpressionEvaluatorVisitor(true);
                 var env = new ExpressionEvaluatorEnvironment { ArbitraryAssignment = System.Collections.Immutable.ImmutableDictionary<object, object>.Empty.AddRange(assignment) };
                 return ((T3)evaluator.Visit(expression, env), evaluator.PathConstraint, evaluator.PathConstraintSymbolicEnvironment);
             }
 
-            Option<(T1, T2)> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input1, input2, solverType);
+            Option<(T1, T2)> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input1, input2, solverType, timeout);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }
@@ -94,6 +98,7 @@ namespace ZenLib.SymbolicExecution
         /// <param name="input2">The second symbolic input.</param>
         /// <param name="input3">The third symbolic input.</param>
         /// <param name="solverType">The solver to use.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>A collection of inputs.</returns>
         public static IEnumerable<(T1, T2, T3)> GenerateInputs<T1, T2, T3, T4>(
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>> function,
@@ -101,7 +106,8 @@ namespace ZenLib.SymbolicExecution
             Zen<T1> input1,
             Zen<T2> input2,
             Zen<T3> input3,
-            SolverType solverType)
+            SolverType solverType,
+            TimeSpan? timeout)
         {
             var expression = function(input1, input2, input3);
             var assume = precondition(input1, input2, input3);
@@ -109,14 +115,14 @@ namespace ZenLib.SymbolicExecution
             (T4, PathConstraint, Dictionary<long, object>) interpretFunction((T1, T2, T3) e)
             {
                 var assignment = ModelCheckerFactory
-                    .CreateModelChecker(solverType, ModelCheckerContext.Solving, null, emptyArguments)
+                    .CreateModelChecker(solverType, ModelCheckerContext.Solving, null, emptyArguments, timeout)
                     .ModelCheck(And(input1 == e.Item1, input2 == e.Item2, input3 == e.Item3), emptyArguments);
                 var evaluator = new ExpressionEvaluatorVisitor(true);
                 var env = new ExpressionEvaluatorEnvironment { ArbitraryAssignment = System.Collections.Immutable.ImmutableDictionary<object, object>.Empty.AddRange(assignment) };
                 return ((T4)evaluator.Visit(expression, env), evaluator.PathConstraint, evaluator.PathConstraintSymbolicEnvironment);
             }
 
-            Option<(T1, T2, T3)> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input1, input2, input3, solverType);
+            Option<(T1, T2, T3)> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input1, input2, input3, solverType, timeout);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }
@@ -131,6 +137,7 @@ namespace ZenLib.SymbolicExecution
         /// <param name="input3">The third symbolic input.</param>
         /// <param name="input4">The fourth symbolic input.</param>
         /// <param name="solverType">The solver to use.</param>
+        /// <param name="timeout">The optional solver timeout.</param>
         /// <returns>A collection of inputs.</returns>
         public static IEnumerable<(T1, T2, T3, T4)> GenerateInputs<T1, T2, T3, T4, T5>(
             Func<Zen<T1>, Zen<T2>, Zen<T3>, Zen<T4>, Zen<T5>> function,
@@ -139,7 +146,8 @@ namespace ZenLib.SymbolicExecution
             Zen<T2> input2,
             Zen<T3> input3,
             Zen<T4> input4,
-            SolverType solverType)
+            SolverType solverType,
+            TimeSpan? timeout)
         {
             var expression = function(input1, input2, input3, input4);
             var assume = precondition(input1, input2, input3, input4);
@@ -147,14 +155,14 @@ namespace ZenLib.SymbolicExecution
             (T5, PathConstraint, Dictionary<long, object>) interpretFunction((T1, T2, T3, T4) e)
             {
                 var assignment = ModelCheckerFactory
-                    .CreateModelChecker(solverType, ModelCheckerContext.Solving, null, emptyArguments)
+                    .CreateModelChecker(solverType, ModelCheckerContext.Solving, null, emptyArguments, timeout)
                     .ModelCheck(And(input1 == e.Item1, input2 == e.Item2, input3 == e.Item3, input4 == e.Item4), emptyArguments);
                 var evaluator = new ExpressionEvaluatorVisitor(true);
                 var env = new ExpressionEvaluatorEnvironment { ArbitraryAssignment = System.Collections.Immutable.ImmutableDictionary<object, object>.Empty.AddRange(assignment) };
                 return ((T5)evaluator.Visit(expression, env), evaluator.PathConstraint, evaluator.PathConstraintSymbolicEnvironment);
             }
 
-            Option<(T1, T2, T3, T4)> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input1, input2, input3, input4, solverType);
+            Option<(T1, T2, T3, T4)> findFunction(Zen<bool> e, Dictionary<long, object> env) => SymbolicEvaluator.Find(e, env, input1, input2, input3, input4, solverType, timeout);
 
             return GenerateInputsSage(assume, findFunction, interpretFunction);
         }


### PR DESCRIPTION
Adds a `SolverConfig` class to encapsulate parameters to the `Solve`, `Maximize`, `Find`, and `GenerateInputs` methods. This includes an optional solver timeout parameter that works for the Z3 solver.