### PR TITLE
fix issue with unicode surrogate pairs in regex matching

### DIFF
--- a/ZenLib.Tests/RegexTests.cs
+++ b/ZenLib.Tests/RegexTests.cs
@@ -575,6 +575,19 @@ namespace ZenLib.Tests
             Assert.AreEqual(expected, a3.IsMatch(bytes3));
         }
 
+        /// <summary>
+        /// Test that Regex parsing produces the right AST.
+        /// </summary>
+        [TestMethod]
+        [DataRow("^[fF][oO][oO]𝅘𝅥𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲⛄⛄⛄$", "foo𝅘𝅥𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲⛄⛄⛄", true)]
+        [DataRow("^[fF][oO][oO]𝅘𝅥𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲⛄⛄⛄$", "FOO𝅘𝅥𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲⛄⛄⛄", true)]
+        [DataRow("^𝅘𝅥𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲⛄⛄⛄$", "𝅘𝅥𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲⛄⛄⛄", true)]
+        public void TestRegexParsingAstUnicode(string regex, string input, bool expected)
+        {
+            var r = Regex.Parse(regex);
+            Assert.AreEqual(expected, r.IsMatch(input.ToCharArray()));
+        }
+
         private void CheckIsMatch<T>(Regex<T> regex, IEnumerable<T> sequence) where T : IComparable<T>
         {
             var a = regex.ToAutomaton();

--- a/ZenLib.Tests/StringTests.cs
+++ b/ZenLib.Tests/StringTests.cs
@@ -1,4 +1,4 @@
-// <copyright file="StringTests.cs" company="Microsoft">
+﻿// <copyright file="StringTests.cs" company="Microsoft">
 // Copyright (c) Microsoft. All rights reserved.
 // </copyright>
 
@@ -480,6 +480,20 @@ namespace ZenLib.Tests
         }
 
         /// <summary>
+        /// Test that matching regexes works for unicode strings with surrogate values.
+        /// </summary>
+        [TestMethod]
+        public void TestMatchesRegexUnicodeSurrogate()
+        {
+            var b = Zen.MatchesRegex("𝅘𝅥𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲⛄⛄⛄", Regex.Parse("𝅘𝅥𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲⛄⛄⛄"));
+            var result = b.Evaluate(new System.Collections.Generic.Dictionary<object, object>());
+            Assert.IsTrue(result);
+
+            var str = Zen.Find<string>(s => s == "𝅘𝅥𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲⛄⛄⛄").Value;
+            Assert.AreEqual("𝅘𝅥𝅘𝅥𝅮𝅘𝅥𝅯𝅘𝅥𝅰𝅘𝅥𝅱𝅘𝅥𝅲⛄⛄⛄", str);
+        }
+
+        /// <summary>
         /// Test string matchesregex.
         /// </summary>
         [TestMethod]
@@ -554,7 +568,10 @@ namespace ZenLib.Tests
         {
             var seq = new Seq<char>().Add((char)0xd800).Add((char)0xdfff);
             var s = Zen.Constraint<string>(s => s == Seq.AsString(seq)).Find();
-            Assert.AreEqual(@"\u{D800}\u{DFFF}", s.Value);
+            var chars = s.Value.ToCharArray();
+            Assert.AreEqual(2, chars.Length);
+            Assert.AreEqual((char)0xd800, chars[0]);
+            Assert.AreEqual((char)0xdfff, chars[1]);
         }
 
         /// <summary>

--- a/ZenLib/Common/CommonUtilities.cs
+++ b/ZenLib/Common/CommonUtilities.cs
@@ -359,24 +359,5 @@ namespace ZenLib
         {
             return @"\u{" + ((long)c).ToString("X4") + "}";
         }
-
-        /// <summary>
-        /// Convert a char to a UTF-16 string.
-        /// </summary>
-        /// <returns>A string that is either a single character or a surrogate pair.</returns>
-        public static string CharToString(char c)
-        {
-            var intVal = (int)c;
-
-            // we need to leave escaped any characters in the range d800-dfff since
-            // these characters can not be represented in strings as they are part
-            // of a surrogate pair used for UTF-16 encodings.
-            if (intVal >= 0xd800 && intVal <= 0xdfff)
-            {
-                return @"\u{" + intVal.ToString("X4") + "}";
-            }
-
-            return c.ToString();
-        }
     }
 }

--- a/ZenLib/DataTypes/Seq.cs
+++ b/ZenLib/DataTypes/Seq.cs
@@ -81,6 +81,8 @@ namespace ZenLib
         public bool MatchesRegex(Regex<T> regex)
         {
             Contract.AssertNotNull(regex);
+            Console.WriteLine(regex);
+            Console.WriteLine(this);
             return regex.IsMatch(this.Values);
         }
 
@@ -493,7 +495,8 @@ namespace ZenLib
         /// <returns>The string for the bytes.</returns>
         public static string AsString(this Seq<char> seq)
         {
-            return string.Join(string.Empty, seq.Values.Select(c => CommonUtilities.CharToString(c)));
+            return new string(seq.Values.ToArray());
+            // return string.Join(string.Empty, seq.Values.Select(c => CommonUtilities.CharToString(c)));
         }
 
         /// <summary>

--- a/ZenLib/DataTypes/Seq.cs
+++ b/ZenLib/DataTypes/Seq.cs
@@ -81,8 +81,6 @@ namespace ZenLib
         public bool MatchesRegex(Regex<T> regex)
         {
             Contract.AssertNotNull(regex);
-            Console.WriteLine(regex);
-            Console.WriteLine(this);
             return regex.IsMatch(this.Values);
         }
 
@@ -496,7 +494,6 @@ namespace ZenLib
         public static string AsString(this Seq<char> seq)
         {
             return new string(seq.Values.ToArray());
-            // return string.Join(string.Empty, seq.Values.Select(c => CommonUtilities.CharToString(c)));
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes an issue where unicode surrogate pairs in the 0xd000 to 0xdfff range are escaped. This causes regex matching to fail for some unicode symbols.