### PR TITLE
Add extension methods for enumerables

### DIFF
--- a/ZenLib.Tests/EnumerableExtensionsTests.cs
+++ b/ZenLib.Tests/EnumerableExtensionsTests.cs
@@ -1,0 +1,88 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ZenLib.Tests;
+
+using static ZenLib.Tests.TestHelper;
+using static ZenLib.Zen;
+
+/// <summary>
+/// Tests for enumerable extension methods.
+/// </summary>
+[TestClass]
+[ExcludeFromCodeCoverage]
+public class EnumerableExtensionsTests
+{
+  /// <summary>
+  /// Test that exists of an empty enumerable is false.
+  /// </summary>
+  [TestMethod]
+  public void TestExistsEmpty()
+  {
+    CheckAgreement(() => False() == Enumerable.Empty<bool>().Exists(_ => True()));
+  }
+
+  /// <summary>
+  /// Test that exists of a 1-element enumerable is the element itself.
+  /// </summary>
+  [TestMethod]
+  public void TestExistsSingle()
+  {
+    CheckValid<bool>(b => b == Enumerable.Repeat(b, 1).Exists(i => i));
+  }
+
+  /// <summary>
+  /// Test that exists of a 2-element enumerable is an or.
+  /// </summary>
+  [TestMethod]
+  public void TestExistsTwo()
+  {
+    CheckValid<bool, bool>((x, y) => Or(x, y) == new[] { x, y }.Exists(i => i));
+  }
+
+  /// <summary>
+  /// Test that exists of a 3-element enumerable is an or.
+  /// </summary>
+  [TestMethod]
+  public void TestExistsThree()
+  {
+    CheckValid<bool, bool, bool>((x, y, z) => Or(x, y, z) == new[] { x, y, z }.Exists(i => i));
+  }
+
+  /// <summary>
+  /// Test that forall of an empty enumerable is true.
+  /// </summary>
+  [TestMethod]
+  public void TestForAllEmpty()
+  {
+    CheckAgreement(() => True() == Enumerable.Empty<bool>().ForAll(_ => False()));
+  }
+
+  /// <summary>
+  /// Test that forall of a 1-element enumerable is the element itself.
+  /// </summary>
+  [TestMethod]
+  public void TestForAllSingle()
+  {
+    CheckValid<bool>(b => b == Enumerable.Repeat(b, 1).ForAll(i => i));
+  }
+
+  /// <summary>
+  /// Test that forall of a 2-element enumerable is an and.
+  /// </summary>
+  [TestMethod]
+  public void TestForAllTwo()
+  {
+    CheckValid<bool, bool>((x, y) => And(x, y) == new[] { x, y }.ForAll(i => i));
+  }
+
+  /// <summary>
+  /// Test that forall of a 3-element enumerable is an and.
+  /// </summary>
+  [TestMethod]
+  public void TestForAllThree()
+  {
+    CheckValid<bool, bool, bool>((x, y, z) => And(x, y, z) == new[] { x, y, z }.ForAll(i => i));
+  }
+}

--- a/ZenLib/Language/Ast/ZenEnumerableExtensions.cs
+++ b/ZenLib/Language/Ast/ZenEnumerableExtensions.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ZenLib
+{
+  /// <summary>
+  /// Extensions of System.Linq for producing Zen expressions.
+  /// Lifting of Linq methods to Zen types.
+  /// </summary>
+  public static class ZenEnumerableExtensions
+  {
+    /// <summary>
+    /// Compute the or of an enumerable of values according to the given predicate.
+    /// </summary>
+    /// <param name="enumerable">The enumerable.</param>
+    /// <param name="predicate">A predicate from the enumerable's element type to Zen booleans.</param>
+    /// <typeparam name="T">The type of the enumerable's elements.</typeparam>
+    /// <returns>Zen value.</returns>
+    public static Zen<bool> Exists<T>(this IEnumerable<T> enumerable, Func<T, Zen<bool>> predicate) =>
+      enumerable.Aggregate(Zen.False(), (b, e) => Zen.Or(b, predicate(e)));
+
+    /// <summary>
+    /// Compute the and of an enumerable of values according to the given predicate.
+    /// </summary>
+    /// <param name="enumerable">The enumerable.</param>
+    /// <param name="predicate">A predicate from the enumerable's element type to Zen booleans.</param>
+    /// <typeparam name="T">The type of the enumerable's elements.</typeparam>
+    /// <returns>Zen value.</returns>
+    public static Zen<bool> ForAll<T>(this IEnumerable<T> enumerable, Func<T, Zen<bool>> predicate) =>
+      enumerable.Aggregate(Zen.True(), (b, e) => Zen.And(b, predicate(e)));
+  }
+}


### PR DESCRIPTION
Add Exists (equivalent to Enumerable.Any) and ForAll (equivalent to Enumerable.All) extension methods. These can be used as shorthands for constructing boolean Zen values over an enumerable, when the desired result is an Or or an And (respectively) over all the enumerable's values.