### PR TITLE
Add additional `Option` methods

### DIFF
--- a/ZenLib.Tests/OptionTests.cs
+++ b/ZenLib.Tests/OptionTests.cs
@@ -132,12 +132,12 @@ namespace ZenLib.Tests
     }
 
     /// <summary>
-    /// Test option some or default.
+    /// Test option OrElse.
     /// </summary>
     [TestMethod]
-    public void TestOptionSomeOrDefault()
+    public void TestOptionOrElse()
     {
-      var zf = new ZenFunction<Option<int>, Option<int>, Option<int>>((o1, o2) => o1.SomeOrDefault(() => o2));
+      var zf = new ZenFunction<Option<int>, Option<int>, Option<int>>((o1, o2) => o1.OrElse(() => o2));
 
       Assert.AreEqual(Option.Some(1), zf.Evaluate(Option.Some(1), Option.Some(3)));
       Assert.AreEqual(Option.Some(3), zf.Evaluate(Option.None<int>(), Option.Some(3)));
@@ -146,8 +146,8 @@ namespace ZenLib.Tests
       Assert.AreEqual(Option.Some(1), zf.Evaluate(Option.Some(1), Option.Some(3)));
       Assert.AreEqual(Option.Some(3), zf.Evaluate(Option.None<int>(), Option.Some(3)));
 
-      Assert.AreEqual(Option.Some(1), Option.Some(1).SomeOrDefault(() => Option.Some(3)));
-      Assert.AreEqual(Option.Some(3), Option.None<int>().SomeOrDefault(() => Option.Some(3)));
+      Assert.AreEqual(Option.Some(1), Option.Some(1).OrElse(() => Option.Some(3)));
+      Assert.AreEqual(Option.Some(3), Option.None<int>().OrElse(() => Option.Some(3)));
     }
 
     /// <summary>
@@ -290,12 +290,12 @@ namespace ZenLib.Tests
     }
 
     /// <summary>
-    /// Test option SelectMany.
+    /// Test option AndThen.
     /// </summary>
     [TestMethod]
-    public void TestOptionSelectMany()
+    public void TestOptionAndThen()
     {
-      var zf = new ZenFunction<Option<int>, Option<int>>(o => o.SelectMany(i => Option.Create(i + 1)));
+      var zf = new ZenFunction<Option<int>, Option<int>>(o => o.AndThen(i => Option.Create(i + 1)));
 
       Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>()));
       Assert.AreEqual(Option.Some(2), zf.Evaluate(Option.Some(1)));
@@ -306,9 +306,9 @@ namespace ZenLib.Tests
       Assert.AreEqual(Option.Some(2), zf.Evaluate(Option.Some(1)));
       Assert.AreEqual(Option.Some(11), zf.Evaluate(Option.Some(10)));
 
-      Assert.AreEqual(Option.None<int>(), Option.None<int>().SelectMany(i => Option.Some(i + 1)));
-      Assert.AreEqual(Option.Some(2), Option.Some(1).SelectMany(i => Option.Some(i + 1)));
-      Assert.AreEqual(Option.Some(11), Option.Some(10).SelectMany(i => Option.Some(i + 1)));
+      Assert.AreEqual(Option.None<int>(), Option.None<int>().AndThen(i => Option.Some(i + 1)));
+      Assert.AreEqual(Option.Some(2), Option.Some(1).AndThen(i => Option.Some(i + 1)));
+      Assert.AreEqual(Option.Some(11), Option.Some(10).AndThen(i => Option.Some(i + 1)));
     }
 
     /// <summary>
@@ -327,12 +327,12 @@ namespace ZenLib.Tests
     }
 
     /// <summary>
-    /// Test option intersect.
+    /// Test option and.
     /// </summary>
     [TestMethod]
-    public void TestOptionIntersect()
+    public void TestOptionAnd()
     {
-      var zf = new ZenFunction<Option<int>, Option<int>, Option<int>>((o1, o2) => o1.Intersect(o2));
+      var zf = new ZenFunction<Option<int>, Option<int>, Option<int>>((o1, o2) => o1.And(o2));
 
       Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>(), Option.Some(1)));
       Assert.AreEqual(Option.Some(2), zf.Evaluate(Option.Some(1), Option.Some(2)));
@@ -343,18 +343,18 @@ namespace ZenLib.Tests
       Assert.AreEqual(Option.Some(2), zf.Evaluate(Option.Some(1), Option.Some(2)));
       Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.Some(1), Option.None<int>()));
 
-      Assert.AreEqual(Option.None<int>(), Option.None<int>().Intersect(Option.Some(1)));
-      Assert.AreEqual(Option.Some(2), Option.Some(1).Intersect(Option.Some(2)));
-      Assert.AreEqual(Option.None<int>(), Option.Some(1).Intersect(Option.None<int>()));
+      Assert.AreEqual(Option.None<int>(), Option.None<int>().And(Option.Some(1)));
+      Assert.AreEqual(Option.Some(2), Option.Some(1).And(Option.Some(2)));
+      Assert.AreEqual(Option.None<int>(), Option.Some(1).And(Option.None<int>()));
     }
 
     /// <summary>
-    /// Test option union.
+    /// Test option or.
     /// </summary>
     [TestMethod]
-    public void TestOptionUnion()
+    public void TestOptionOr()
     {
-      var zf = new ZenFunction<Option<int>, Option<int>, Option<int>>((o1, o2) => o1.Union(o2));
+      var zf = new ZenFunction<Option<int>, Option<int>, Option<int>>((o1, o2) => o1.Or(o2));
 
       Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>(), Option.None<int>()));
       Assert.AreEqual(Option.Some(1), zf.Evaluate(Option.None<int>(), Option.Some(1)));
@@ -365,9 +365,9 @@ namespace ZenLib.Tests
       Assert.AreEqual(Option.Some(1), zf.Evaluate(Option.None<int>(), Option.Some(1)));
       Assert.AreEqual(Option.Some(1), zf.Evaluate(Option.Some(1), Option.None<int>()));
 
-      Assert.AreEqual(Option.None<int>(), Option.None<int>().Union(Option.None<int>()));
-      Assert.AreEqual(Option.Some(1), Option.None<int>().Union(Option.Some(1)));
-      Assert.AreEqual(Option.Some(1), Option.Some(1).Union(Option.None<int>()));
+      Assert.AreEqual(Option.None<int>(), Option.None<int>().Or(Option.None<int>()));
+      Assert.AreEqual(Option.Some(1), Option.None<int>().Or(Option.Some(1)));
+      Assert.AreEqual(Option.Some(1), Option.Some(1).Or(Option.None<int>()));
     }
   }
 }

--- a/ZenLib.Tests/OptionTests.cs
+++ b/ZenLib.Tests/OptionTests.cs
@@ -4,285 +4,370 @@
 
 namespace ZenLib.Tests
 {
-    using System.Diagnostics.CodeAnalysis;
-    using System.Numerics;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using ZenLib;
-    using ZenLib.Tests.Network;
-    using static ZenLib.Tests.TestHelper;
-    using static ZenLib.Zen;
+  using System.Diagnostics.CodeAnalysis;
+  using System.Numerics;
+  using Microsoft.VisualStudio.TestTools.UnitTesting;
+  using ZenLib;
+  using ZenLib.Tests.Network;
+  using static ZenLib.Tests.TestHelper;
+  using static ZenLib.Zen;
+
+  /// <summary>
+  /// Tests for the Zen option type.
+  /// </summary>
+  [TestClass]
+  [ExcludeFromCodeCoverage]
+  public class OptionTests
+  {
+    /// <summary>
+    /// Test that option equality works.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionEquality()
+    {
+      Assert.AreNotEqual(Option.None<int>(), null);
+      Assert.AreNotEqual(Option.None<int>(), 4);
+      Assert.AreEqual(Option.None<int>(), Option.None<int>());
+      Assert.AreEqual(new Option<int>(false, 1), new Option<int>(false, 2));
+      Assert.AreNotEqual(Option.None<int>(), Option.Some(0));
+      Assert.AreNotEqual(Option.Some(0), Option.None<int>());
+      Assert.AreEqual(Option.Some(0), Option.Some(0));
+      Assert.AreNotEqual(Option.Some(0), Option.Some(1));
+      Assert.AreNotEqual(Option.None<int>().GetHashCode(), Option.Some(1).GetHashCode());
+    }
 
     /// <summary>
-    /// Tests for the Zen option type.
+    /// Test that finding an option works.
     /// </summary>
-    [TestClass]
-    [ExcludeFromCodeCoverage]
-    public class OptionTests
+    [TestMethod]
+    public void TestOptionFind()
     {
-        /// <summary>
-        /// Test that option equality works.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionEquality()
-        {
-            Assert.AreNotEqual(Option.None<int>(), null);
-            Assert.AreNotEqual(Option.None<int>(), 4);
-            Assert.AreEqual(Option.None<int>(), Option.None<int>());
-            Assert.AreEqual(new Option<int>(false, 1), new Option<int>(false, 2));
-            Assert.AreNotEqual(Option.None<int>(), Option.Some(0));
-            Assert.AreNotEqual(Option.Some(0), Option.None<int>());
-            Assert.AreEqual(Option.Some(0), Option.Some(0));
-            Assert.AreNotEqual(Option.Some(0), Option.Some(1));
-            Assert.AreNotEqual(Option.None<int>().GetHashCode(), Option.Some(1).GetHashCode());
-        }
-
-        /// <summary>
-        /// Test that finding an option works.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionFind()
-        {
-            var zf = new ZenFunction<Option<int>, bool>(o => o.IsSome());
-            var example = zf.Find((i, o) => o);
-            Assert.IsTrue(example.HasValue);
-            Assert.AreEqual(Option.Some(0), example.Value);
-        }
-
-        /// <summary>
-        /// Test none has no value.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionNone()
-        {
-            CheckAgreement<Option<int>>(o => o.IsSome());
-        }
-
-        /// <summary>
-        /// Test some returns the correct value.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionSomeInt()
-        {
-            RandomBytes(x => CheckAgreement<Option<int>>(o => And(o.IsSome(), o.Value() == Constant<int>(x))));
-        }
-
-        /// <summary>
-        /// Test option with tuple underneath.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionSomeTuple()
-        {
-            RandomBytes(x =>
-            {
-                CheckAgreement<Option<Pair<byte, byte>>>(o =>
-                {
-                    var item1 = o.Value().Item1() == x;
-                    var item2 = o.Value().Item2() == x;
-                    return And(o.IsSome(), Or(item1, item2));
-                });
-            });
-        }
-
-        /// <summary>
-        /// Test option match.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionMatch()
-        {
-            CheckValid<Option<int>>(o =>
-                Implies(And(o.IsSome(), o.Value() <= Constant<int>(4)),
-                    o.Case(none: () => False(), some: v => v <= Constant<int>(4))));
-        }
-
-        /// <summary>
-        /// Test option value or.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionNullValueType()
-        {
-            CheckAgreement<Option<Pair<int, int>>>(o => o.Value().Item1() == o.Value().Item2());
-        }
-
-        /// <summary>
-        /// Test option value or.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionValueOrDefaultValid()
-        {
-            CheckValid<Option<int>>(o => o.Select(v => Constant(2)).ValueOrDefault(Constant(2)) == Constant(2));
-        }
-
-        /// <summary>
-        /// Test option value or default.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionValueOrDefault()
-        {
-            var zf = new ZenFunction<Option<int>, int, int>((o, i) => o.ValueOrDefault(i));
-
-            Assert.AreEqual(1, zf.Evaluate(Option.Some(1), 3));
-            Assert.AreEqual(3, zf.Evaluate(Option.None<int>(), 3));
-
-            zf.Compile();
-            Assert.AreEqual(1, zf.Evaluate(Option.Some(1), 3));
-            Assert.AreEqual(3, zf.Evaluate(Option.None<int>(), 3));
-
-            Assert.AreEqual(1, Option.Some(1).ValueOrDefault(3));
-            Assert.AreEqual(3, Option.None<int>().ValueOrDefault(3));
-        }
-
-        /// <summary>
-        /// Test option IsSome.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionIsSome()
-        {
-            var zf = new ZenFunction<Option<int>, bool>(o => o.IsSome());
-
-            Assert.AreEqual(true, zf.Evaluate(Option.Some(1)));
-            Assert.AreEqual(false, zf.Evaluate(Option.None<int>()));
-
-            zf.Compile();
-            Assert.AreEqual(true, zf.Evaluate(Option.Some(1)));
-            Assert.AreEqual(false, zf.Evaluate(Option.None<int>()));
-
-            Assert.AreEqual(true, Option.Some(1).IsSome());
-            Assert.AreEqual(false, Option.None<int>().IsSome());
-        }
-
-        /// <summary>
-        /// Test option IsNone.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionIsNone()
-        {
-            var zf = new ZenFunction<Option<int>, bool>(o => o.IsNone());
-
-            Assert.AreEqual(false, zf.Evaluate(Option.Some(1)));
-            Assert.AreEqual(true, zf.Evaluate(Option.None<int>()));
-
-            zf.Compile();
-            Assert.AreEqual(false, zf.Evaluate(Option.Some(1)));
-            Assert.AreEqual(true, zf.Evaluate(Option.None<int>()));
-
-            Assert.AreEqual(false, Option.Some(1).IsNone());
-            Assert.AreEqual(true, Option.None<int>().IsNone());
-        }
-
-        /// <summary>
-        /// Test option where.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionWhereValid()
-        {
-            CheckValid<Option<int>>(o =>
-                Implies(And(o.IsSome(), o.Value() <= Constant<int>(4)), Not(o.Where(v => v > Constant<int>(4)).IsSome())));
-        }
-
-        /// <summary>
-        /// Test option Where.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionWhere()
-        {
-            var zf = new ZenFunction<Option<int>, Option<int>>(o => o.Where(i => i > 10));
-
-            Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.Some(1)));
-            Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>()));
-            Assert.AreEqual(Option.Some<int>(11), zf.Evaluate(Option.Some(11)));
-
-            zf.Compile();
-            Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.Some(1)));
-            Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>()));
-            Assert.AreEqual(Option.Some<int>(11), zf.Evaluate(Option.Some(11)));
-
-            Assert.AreEqual(Option.None<int>(), Option.Some(1).Where(i => i > 10));
-            Assert.AreEqual(Option.None<int>(), Option.None<int>().Where(i => i > 10));
-            Assert.AreEqual(Option.Some<int>(11), Option.Some(11).Where(i => i > 10));
-        }
-
-        /// <summary>
-        /// Test option to sequence.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionToSequenceValid1()
-        {
-            CheckAgreement<Option<int>>(o => o.ToFSeq().IsEmpty(), runBdds: false);
-        }
-
-        /// <summary>
-        /// Test option to sequence.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionToSequenceValid2()
-        {
-            CheckValid<Option<int>>(o => Implies(o.IsSome(), o.ToFSeq().Length() == (BigInteger)1), runBdds: false);
-        }
-
-        /// <summary>
-        /// Test option ToSequence.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionToSequence()
-        {
-            var zf = new ZenFunction<Option<int>, FSeq<int>>(o => o.ToFSeq());
-
-            Assert.AreEqual(1, zf.Evaluate(Option.Some(1)).ToList().Count);
-            Assert.AreEqual(0, zf.Evaluate(Option.None<int>()).ToList().Count);
-
-            zf.Compile();
-            Assert.AreEqual(1, zf.Evaluate(Option.Some(1)).ToList().Count);
-            Assert.AreEqual(0, zf.Evaluate(Option.None<int>()).ToList().Count);
-
-            Assert.AreEqual(1, Option.Some(1).ToSequence().ToList().Count);
-            Assert.AreEqual(0, Option.None<int>().ToSequence().ToList().Count);
-        }
-
-        /// <summary>
-        /// Test option select.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionSelectValid()
-        {
-            CheckValid<Option<int>>(o =>
-                Implies(o.IsSome(), o.Select(v => v + Constant<int>(1)).Value() == o.Value() + Constant<int>(1)));
-        }
-
-        /// <summary>
-        /// Test option Where.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionSelect()
-        {
-            var zf = new ZenFunction<Option<int>, Option<int>>(o => o.Select(i => i + 1));
-
-            Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>()));
-            Assert.AreEqual(Option.Some(2), zf.Evaluate(Option.Some(1)));
-            Assert.AreEqual(Option.Some(11), zf.Evaluate(Option.Some(10)));
-
-            zf.Compile();
-            Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>()));
-            Assert.AreEqual(Option.Some(2), zf.Evaluate(Option.Some(1)));
-            Assert.AreEqual(Option.Some(11), zf.Evaluate(Option.Some(10)));
-
-            Assert.AreEqual(Option.None<int>(), Option.None<int>().Select(i => i + 1));
-            Assert.AreEqual(Option.Some(2), Option.Some(1).Select(i => i + 1));
-            Assert.AreEqual(Option.Some(11), Option.Some(10).Select(i => i + 1));
-        }
-
-        /// <summary>
-        /// Test non-null default.
-        /// </summary>
-        [TestMethod]
-        public void TestOptionDefault()
-        {
-            var f = new ZenFunction<IpHeader>(() =>
-            {
-                var x = Option.Null<IpHeader>();
-                return x.Value();
-            });
-
-            Assert.AreEqual(0U, f.Evaluate().DstIp.Value);
-        }
+      var zf = new ZenFunction<Option<int>, bool>(o => o.IsSome());
+      var example = zf.Find((i, o) => o);
+      Assert.IsTrue(example.HasValue);
+      Assert.AreEqual(Option.Some(0), example.Value);
     }
+
+    /// <summary>
+    /// Test none has no value.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionNone()
+    {
+      CheckAgreement<Option<int>>(o => o.IsSome());
+    }
+
+    /// <summary>
+    /// Test some returns the correct value.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionSomeInt()
+    {
+      RandomBytes(x => CheckAgreement<Option<int>>(o => And(o.IsSome(), o.Value() == Constant<int>(x))));
+    }
+
+    /// <summary>
+    /// Test option with tuple underneath.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionSomeTuple()
+    {
+      RandomBytes(x =>
+      {
+        CheckAgreement<Option<Pair<byte, byte>>>(o =>
+        {
+          var item1 = o.Value().Item1() == x;
+          var item2 = o.Value().Item2() == x;
+          return And(o.IsSome(), Or(item1, item2));
+        });
+      });
+    }
+
+    /// <summary>
+    /// Test option match.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionMatch()
+    {
+      CheckValid<Option<int>>(o =>
+        Implies(And(o.IsSome(), o.Value() <= Constant<int>(4)),
+          o.Case(none: () => False(), some: v => v <= Constant<int>(4))));
+    }
+
+    /// <summary>
+    /// Test option value or.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionNullValueType()
+    {
+      CheckAgreement<Option<Pair<int, int>>>(o => o.Value().Item1() == o.Value().Item2());
+    }
+
+    /// <summary>
+    /// Test option value or.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionValueOrDefaultValid()
+    {
+      CheckValid<Option<int>>(o => o.Select(v => Constant(2)).ValueOrDefault(Constant(2)) == Constant(2));
+    }
+
+    /// <summary>
+    /// Test option value or default.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionValueOrDefault()
+    {
+      var zf = new ZenFunction<Option<int>, int, int>((o, i) => o.ValueOrDefault(i));
+
+      Assert.AreEqual(1, zf.Evaluate(Option.Some(1), 3));
+      Assert.AreEqual(3, zf.Evaluate(Option.None<int>(), 3));
+
+      zf.Compile();
+      Assert.AreEqual(1, zf.Evaluate(Option.Some(1), 3));
+      Assert.AreEqual(3, zf.Evaluate(Option.None<int>(), 3));
+
+      Assert.AreEqual(1, Option.Some(1).ValueOrDefault(3));
+      Assert.AreEqual(3, Option.None<int>().ValueOrDefault(3));
+    }
+
+    /// <summary>
+    /// Test option some or default.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionSomeOrDefault()
+    {
+      var zf = new ZenFunction<Option<int>, Option<int>, Option<int>>((o1, o2) => o1.SomeOrDefault(() => o2));
+
+      Assert.AreEqual(Option.Some(1), zf.Evaluate(Option.Some(1), Option.Some(3)));
+      Assert.AreEqual(Option.Some(3), zf.Evaluate(Option.None<int>(), Option.Some(3)));
+
+      zf.Compile();
+      Assert.AreEqual(Option.Some(1), zf.Evaluate(Option.Some(1), Option.Some(3)));
+      Assert.AreEqual(Option.Some(3), zf.Evaluate(Option.None<int>(), Option.Some(3)));
+
+      Assert.AreEqual(Option.Some(1), Option.Some(1).SomeOrDefault(() => Option.Some(3)));
+      Assert.AreEqual(Option.Some(3), Option.None<int>().SomeOrDefault(() => Option.Some(3)));
+    }
+
+    /// <summary>
+    /// Test option IsSome.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionIsSome()
+    {
+      var zf = new ZenFunction<Option<int>, bool>(o => o.IsSome());
+
+      Assert.AreEqual(true, zf.Evaluate(Option.Some(1)));
+      Assert.AreEqual(false, zf.Evaluate(Option.None<int>()));
+
+      zf.Compile();
+      Assert.AreEqual(true, zf.Evaluate(Option.Some(1)));
+      Assert.AreEqual(false, zf.Evaluate(Option.None<int>()));
+
+      Assert.AreEqual(true, Option.Some(1).IsSome());
+      Assert.AreEqual(false, Option.None<int>().IsSome());
+    }
+
+    /// <summary>
+    /// Test option IsNone.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionIsNone()
+    {
+      var zf = new ZenFunction<Option<int>, bool>(o => o.IsNone());
+
+      Assert.AreEqual(false, zf.Evaluate(Option.Some(1)));
+      Assert.AreEqual(true, zf.Evaluate(Option.None<int>()));
+
+      zf.Compile();
+      Assert.AreEqual(false, zf.Evaluate(Option.Some(1)));
+      Assert.AreEqual(true, zf.Evaluate(Option.None<int>()));
+
+      Assert.AreEqual(false, Option.Some(1).IsNone());
+      Assert.AreEqual(true, Option.None<int>().IsNone());
+    }
+
+    /// <summary>
+    /// Test option where.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionWhereValid()
+    {
+      CheckValid<Option<int>>(o =>
+        Implies(And(o.IsSome(), o.Value() <= Constant<int>(4)), Not(o.Where(v => v > Constant<int>(4)).IsSome())));
+    }
+
+    /// <summary>
+    /// Test option Where.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionWhere()
+    {
+      var zf = new ZenFunction<Option<int>, Option<int>>(o => o.Where(i => i > 10));
+
+      Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.Some(1)));
+      Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>()));
+      Assert.AreEqual(Option.Some<int>(11), zf.Evaluate(Option.Some(11)));
+
+      zf.Compile();
+      Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.Some(1)));
+      Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>()));
+      Assert.AreEqual(Option.Some<int>(11), zf.Evaluate(Option.Some(11)));
+
+      Assert.AreEqual(Option.None<int>(), Option.Some(1).Where(i => i > 10));
+      Assert.AreEqual(Option.None<int>(), Option.None<int>().Where(i => i > 10));
+      Assert.AreEqual(Option.Some<int>(11), Option.Some(11).Where(i => i > 10));
+    }
+
+    /// <summary>
+    /// Test option to sequence.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionToSequenceValid1()
+    {
+      CheckAgreement<Option<int>>(o => o.ToFSeq().IsEmpty(), runBdds: false);
+    }
+
+    /// <summary>
+    /// Test option to sequence.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionToSequenceValid2()
+    {
+      CheckValid<Option<int>>(o => Implies(o.IsSome(), o.ToFSeq().Length() == (BigInteger)1), runBdds: false);
+    }
+
+    /// <summary>
+    /// Test option ToSequence.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionToSequence()
+    {
+      var zf = new ZenFunction<Option<int>, FSeq<int>>(o => o.ToFSeq());
+
+      Assert.AreEqual(1, zf.Evaluate(Option.Some(1)).ToList().Count);
+      Assert.AreEqual(0, zf.Evaluate(Option.None<int>()).ToList().Count);
+
+      zf.Compile();
+      Assert.AreEqual(1, zf.Evaluate(Option.Some(1)).ToList().Count);
+      Assert.AreEqual(0, zf.Evaluate(Option.None<int>()).ToList().Count);
+
+      Assert.AreEqual(1, Option.Some(1).ToSequence().ToList().Count);
+      Assert.AreEqual(0, Option.None<int>().ToSequence().ToList().Count);
+    }
+
+    /// <summary>
+    /// Test option select.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionSelectValid()
+    {
+      CheckValid<Option<int>>(o =>
+        Implies(o.IsSome(), o.Select(v => v + Constant<int>(1)).Value() == o.Value() + Constant<int>(1)));
+    }
+
+    /// <summary>
+    /// Test option Select.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionSelect()
+    {
+      var zf = new ZenFunction<Option<int>, Option<int>>(o => o.Select(i => i + 1));
+
+      Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>()));
+      Assert.AreEqual(Option.Some(2), zf.Evaluate(Option.Some(1)));
+      Assert.AreEqual(Option.Some(11), zf.Evaluate(Option.Some(10)));
+
+      zf.Compile();
+      Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>()));
+      Assert.AreEqual(Option.Some(2), zf.Evaluate(Option.Some(1)));
+      Assert.AreEqual(Option.Some(11), zf.Evaluate(Option.Some(10)));
+
+      Assert.AreEqual(Option.None<int>(), Option.None<int>().Select(i => i + 1));
+      Assert.AreEqual(Option.Some(2), Option.Some(1).Select(i => i + 1));
+      Assert.AreEqual(Option.Some(11), Option.Some(10).Select(i => i + 1));
+    }
+
+    /// <summary>
+    /// Test option SelectMany.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionSelectMany()
+    {
+      var zf = new ZenFunction<Option<int>, Option<int>>(o => o.SelectMany(i => Option.Create(i + 1)));
+
+      Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>()));
+      Assert.AreEqual(Option.Some(2), zf.Evaluate(Option.Some(1)));
+      Assert.AreEqual(Option.Some(11), zf.Evaluate(Option.Some(10)));
+
+      zf.Compile();
+      Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>()));
+      Assert.AreEqual(Option.Some(2), zf.Evaluate(Option.Some(1)));
+      Assert.AreEqual(Option.Some(11), zf.Evaluate(Option.Some(10)));
+
+      Assert.AreEqual(Option.None<int>(), Option.None<int>().SelectMany(i => Option.Some(i + 1)));
+      Assert.AreEqual(Option.Some(2), Option.Some(1).SelectMany(i => Option.Some(i + 1)));
+      Assert.AreEqual(Option.Some(11), Option.Some(10).SelectMany(i => Option.Some(i + 1)));
+    }
+
+    /// <summary>
+    /// Test non-null default.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionDefault()
+    {
+      var f = new ZenFunction<IpHeader>(() =>
+      {
+        var x = Option.Null<IpHeader>();
+        return x.Value();
+      });
+
+      Assert.AreEqual(0U, f.Evaluate().DstIp.Value);
+    }
+
+    /// <summary>
+    /// Test option intersect.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionIntersect()
+    {
+      var zf = new ZenFunction<Option<int>, Option<int>, Option<int>>((o1, o2) => o1.Intersect(o2));
+
+      Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>(), Option.Some(1)));
+      Assert.AreEqual(Option.Some(2), zf.Evaluate(Option.Some(1), Option.Some(2)));
+      Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.Some(1), Option.None<int>()));
+
+      zf.Compile();
+      Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>(), Option.Some(1)));
+      Assert.AreEqual(Option.Some(2), zf.Evaluate(Option.Some(1), Option.Some(2)));
+      Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.Some(1), Option.None<int>()));
+
+      Assert.AreEqual(Option.None<int>(), Option.None<int>().Intersect(Option.Some(1)));
+      Assert.AreEqual(Option.Some(2), Option.Some(1).Intersect(Option.Some(2)));
+      Assert.AreEqual(Option.None<int>(), Option.Some(1).Intersect(Option.None<int>()));
+    }
+
+    /// <summary>
+    /// Test option union.
+    /// </summary>
+    [TestMethod]
+    public void TestOptionUnion()
+    {
+      var zf = new ZenFunction<Option<int>, Option<int>, Option<int>>((o1, o2) => o1.Union(o2));
+
+      Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>(), Option.None<int>()));
+      Assert.AreEqual(Option.Some(1), zf.Evaluate(Option.None<int>(), Option.Some(1)));
+      Assert.AreEqual(Option.Some(1), zf.Evaluate(Option.Some(1), Option.None<int>()));
+
+      zf.Compile();
+      Assert.AreEqual(Option.None<int>(), zf.Evaluate(Option.None<int>(), Option.None<int>()));
+      Assert.AreEqual(Option.Some(1), zf.Evaluate(Option.None<int>(), Option.Some(1)));
+      Assert.AreEqual(Option.Some(1), zf.Evaluate(Option.Some(1), Option.None<int>()));
+
+      Assert.AreEqual(Option.None<int>(), Option.None<int>().Union(Option.None<int>()));
+      Assert.AreEqual(Option.Some(1), Option.None<int>().Union(Option.Some(1)));
+      Assert.AreEqual(Option.Some(1), Option.Some(1).Union(Option.None<int>()));
+    }
+  }
 }

--- a/ZenLib/DataTypes/Option.cs
+++ b/ZenLib/DataTypes/Option.cs
@@ -53,7 +53,7 @@ namespace ZenLib
         /// </summary>
         /// <param name="other">The default-generating function.</param>
         /// <returns>An option of the underlying type.</returns>
-        public Option<T> SomeOrDefault(Func<Option<T>> other)
+        public Option<T> OrElse(Func<Option<T>> other)
         {
             if (this.HasValue)
             {
@@ -76,10 +76,11 @@ namespace ZenLib
 
         /// <summary>
         /// Map a function that returns an option over an option and "flatten" the result.
+        /// Also known as "flat map" or "bind".
         /// </summary>
         /// <param name="function">The function.</param>
         /// <returns>A new option with the function mapped over the value.</returns>
-        public Option<TResult> SelectMany<TResult>(Func<T, Option<TResult>> function)
+        public Option<TResult> AndThen<TResult>(Func<T, Option<TResult>> function)
         {
             Contract.AssertNotNull(function);
             return this.HasValue ? function(this.Value) : Option.None<TResult>();
@@ -130,25 +131,25 @@ namespace ZenLib
         }
 
         /// <summary>
-        /// Return the "intersection" of the option with another:
+        /// Return the "conjunction" of the option with another:
         /// an option with no value if this option has no value,
         /// otherwise the other option.
         /// </summary>
         /// <param name="other">The other option.</param>
         /// <returns>An option.</returns>
-        public Option<T> Intersect(Option<T> other)
+        public Option<T> And(Option<T> other)
         {
             return !this.HasValue ? this : other;
         }
 
         /// <summary>
-        /// Return the "union" of the option with another:
+        /// Return the "disjunction" of the option with another:
         /// this option if it has a value,
         /// otherwise the other option.
         /// </summary>
         /// <param name="other">The other option.</param>
         /// <returns>An option.</returns>
-        public Option<T> Union(Option<T> other)
+        public Option<T> Or(Option<T> other)
         {
             return this.HasValue ? this : other;
         }
@@ -273,13 +274,14 @@ namespace ZenLib
 
         /// <summary>
         /// The Zen expression for mapping (and projecting) over an option.
+        /// Also known as "flat map" or "bind".
         /// </summary>
         /// <param name="expr">The expression.</param>
         /// <param name="function">The function.</param>
         /// <typeparam name="T1">The expression type.</typeparam>
         /// <typeparam name="T2">The function return type.</typeparam>
         /// <returns>Zen value.</returns>
-        public static Zen<Option<T2>> SelectMany<T1, T2>(this Zen<Option<T1>> expr,
+        public static Zen<Option<T2>> AndThen<T1, T2>(this Zen<Option<T1>> expr,
             Func<Zen<T1>, Zen<Option<T2>>> function)
         {
             Contract.AssertNotNull(expr);
@@ -322,7 +324,7 @@ namespace ZenLib
         /// <param name="expr">The expression.</param>
         /// <param name="function">The function.</param>
         /// <returns>Zen value.</returns>
-        public static Zen<Option<T>> SomeOrDefault<T>(this Zen<Option<T>> expr, Func<Zen<Option<T>>> function)
+        public static Zen<Option<T>> OrElse<T>(this Zen<Option<T>> expr, Func<Zen<Option<T>>> function)
         {
             Contract.AssertNotNull(expr);
             Contract.AssertNotNull(function);
@@ -368,14 +370,14 @@ namespace ZenLib
         }
 
         /// <summary>
-        /// The Zen expression for an "intersection" of two options.
+        /// The Zen expression for a "conjunction" of two options.
         /// None if the first option is None, otherwise the second value.
         /// </summary>
         /// <param name="expr1"></param>
         /// <param name="expr2"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static Zen<Option<T>> Intersect<T>(this Zen<Option<T>> expr1, Zen<Option<T>> expr2)
+        public static Zen<Option<T>> And<T>(this Zen<Option<T>> expr1, Zen<Option<T>> expr2)
         {
             Contract.AssertNotNull(expr1);
             Contract.AssertNotNull(expr2);
@@ -384,14 +386,14 @@ namespace ZenLib
         }
 
         /// <summary>
-        /// The Zen expression for a "union" of two options.
+        /// The Zen expression for a "disjunction" of two options.
         /// The first option if it is Some, otherwise the second value.
         /// </summary>
         /// <param name="expr1"></param>
         /// <param name="expr2"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static Zen<Option<T>> Union<T>(this Zen<Option<T>> expr1, Zen<Option<T>> expr2)
+        public static Zen<Option<T>> Or<T>(this Zen<Option<T>> expr1, Zen<Option<T>> expr2)
         {
             Contract.AssertNotNull(expr1);
             Contract.AssertNotNull(expr2);

--- a/ZenLib/DataTypes/Option.cs
+++ b/ZenLib/DataTypes/Option.cs
@@ -48,6 +48,22 @@ namespace ZenLib
         }
 
         /// <summary>
+        /// Return the option if it has a value, or the result of a function if not.
+        /// Lazy equivalent (without unwrapping) of <see cref="ValueOrDefault"/>.
+        /// </summary>
+        /// <param name="other">The default-generating function.</param>
+        /// <returns>An option of the underlying type.</returns>
+        public Option<T> SomeOrDefault(Func<Option<T>> other)
+        {
+            if (this.HasValue)
+            {
+                return this;
+            }
+
+            return other();
+        }
+
+        /// <summary>
         /// Map a function over an option.
         /// </summary>
         /// <param name="function">The function.</param>
@@ -56,6 +72,17 @@ namespace ZenLib
         {
             Contract.AssertNotNull(function);
             return this.HasValue ? Option.Some(function(this.Value)) : Option.None<TResult>();
+        }
+
+        /// <summary>
+        /// Map a function that returns an option over an option and "flatten" the result.
+        /// </summary>
+        /// <param name="function">The function.</param>
+        /// <returns>A new option with the function mapped over the value.</returns>
+        public Option<TResult> SelectMany<TResult>(Func<T, Option<TResult>> function)
+        {
+            Contract.AssertNotNull(function);
+            return this.HasValue ? function(this.Value) : Option.None<TResult>();
         }
 
         /// <summary>
@@ -100,6 +127,30 @@ namespace ZenLib
         public FSeq<T> ToSequence()
         {
             return this.HasValue ? new FSeq<T>().AddFront(this.Value)  : new FSeq<T>();
+        }
+
+        /// <summary>
+        /// Return the "intersection" of the option with another:
+        /// an option with no value if this option has no value,
+        /// otherwise the other option.
+        /// </summary>
+        /// <param name="other">The other option.</param>
+        /// <returns>An option.</returns>
+        public Option<T> Intersect(Option<T> other)
+        {
+            return !this.HasValue ? this : other;
+        }
+
+        /// <summary>
+        /// Return the "union" of the option with another:
+        /// this option if it has a value,
+        /// otherwise the other option.
+        /// </summary>
+        /// <param name="other">The other option.</param>
+        /// <returns>An option.</returns>
+        public Option<T> Union(Option<T> other)
+        {
+            return this.HasValue ? this : other;
         }
 
         /// <summary>
@@ -221,6 +272,23 @@ namespace ZenLib
         }
 
         /// <summary>
+        /// The Zen expression for mapping (and projecting) over an option.
+        /// </summary>
+        /// <param name="expr">The expression.</param>
+        /// <param name="function">The function.</param>
+        /// <typeparam name="T1">The expression type.</typeparam>
+        /// <typeparam name="T2">The function return type.</typeparam>
+        /// <returns>Zen value.</returns>
+        public static Zen<Option<T2>> SelectMany<T1, T2>(this Zen<Option<T1>> expr,
+            Func<Zen<T1>, Zen<Option<T2>>> function)
+        {
+            Contract.AssertNotNull(expr);
+            Contract.AssertNotNull(function);
+
+            return If(expr.IsSome(), function(expr.Value()), Option.Null<T2>());
+        }
+
+        /// <summary>
         /// The Zen expression for filtering over an option.
         /// </summary>
         /// <param name="expr">The expression.</param>
@@ -231,7 +299,7 @@ namespace ZenLib
             Contract.AssertNotNull(expr);
             Contract.AssertNotNull(function);
 
-            return If(And(expr.IsSome(), function(expr.Value())), expr, Option.Null<T>());
+            return If(Zen.And(expr.IsSome(), function(expr.Value())), expr, Option.Null<T>());
         }
 
         /// <summary>
@@ -249,6 +317,20 @@ namespace ZenLib
         }
 
         /// <summary>
+        /// The Zen expression for an option if it has a value, or the result of a function otherwise.
+        /// </summary>
+        /// <param name="expr">The expression.</param>
+        /// <param name="function">The function.</param>
+        /// <returns>Zen value.</returns>
+        public static Zen<Option<T>> SomeOrDefault<T>(this Zen<Option<T>> expr, Func<Zen<Option<T>>> function)
+        {
+            Contract.AssertNotNull(expr);
+            Contract.AssertNotNull(function);
+
+            return If(expr.IsSome(), expr, function());
+        }
+
+        /// <summary>
         /// The Zen expression for whether an option has a value.
         /// </summary>
         /// <param name="expr">The expression.</param>
@@ -261,7 +343,7 @@ namespace ZenLib
         }
 
         /// <summary>
-        /// The Zen expression for whether an option has a value.
+        /// The Zen expression for whether an option has no value.
         /// </summary>
         /// <param name="expr">The expression.</param>
         /// <returns>Zen value.</returns>
@@ -273,7 +355,7 @@ namespace ZenLib
         }
 
         /// <summary>
-        /// The Zen expression for whether an option has a value.
+        /// The Zen expression for representing the option as a finite sequence.
         /// </summary>
         /// <param name="expr">The expression.</param>
         /// <returns>Zen value.</returns>
@@ -283,6 +365,38 @@ namespace ZenLib
 
             var l = FSeq.Empty<T>();
             return If(expr.IsSome(), l.AddFront(expr.Value()), l);
+        }
+
+        /// <summary>
+        /// The Zen expression for an "intersection" of two options.
+        /// None if the first option is None, otherwise the second value.
+        /// </summary>
+        /// <param name="expr1"></param>
+        /// <param name="expr2"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static Zen<Option<T>> Intersect<T>(this Zen<Option<T>> expr1, Zen<Option<T>> expr2)
+        {
+            Contract.AssertNotNull(expr1);
+            Contract.AssertNotNull(expr2);
+
+            return If(expr1.IsNone(), expr1, expr2);
+        }
+
+        /// <summary>
+        /// The Zen expression for a "union" of two options.
+        /// The first option if it is Some, otherwise the second value.
+        /// </summary>
+        /// <param name="expr1"></param>
+        /// <param name="expr2"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static Zen<Option<T>> Union<T>(this Zen<Option<T>> expr1, Zen<Option<T>> expr2)
+        {
+            Contract.AssertNotNull(expr1);
+            Contract.AssertNotNull(expr2);
+
+            return If(expr1.IsSome(), expr1, expr2);
         }
     }
 }


### PR DESCRIPTION
Add `Option` equivalents of the following `System.Linq.Enumerable` methods:
* `Intersect`: a kind of eager Boolean "and" over 2 options. Returns the second option unless the first is None.
* `Union`: a kind of eager Boolean "or" over 2 options. Returns the first option unless it is None.
* `SelectMany`: a chainable version of Select akin to `Enumerable.SelectMany`. The supplied function returns an option rather than a bare type, and the result type is the function's result type.
* `SomeOrDefault`: a kind of `Enumerable.Concat` over an option and an option-generating thunk. If the option is None, call the thunk to generate a default option.

All names of these new methods are open to revision. These are less common methods and their names vary in other programming languages. Alternatives might be:
* `Option.Intersect` --> `Option.And`
* `Option.Union` --> `Option.Or`
* `Option.SelectMany` --> `Option.Bind` or `Option.AndThen`
* `Option.SomeOrDefault` --> `Option.Concat` or `Option.OrElse`

`SomeOrDefault` is called `or_else` in Rust and C++23. `SelectMany` is variously called `and_then` (Rust, C++23, Elm),
 `bind` (OCaml), or `flat_map` (Nim, Swift). `Intersect` is called `and` in Rust, and `Union` is called `or` in Rust.